### PR TITLE
Add pending status to users

### DIFF
--- a/cp_684cb2e048560/include/modules/clients/clients.php
+++ b/cp_684cb2e048560/include/modules/clients/clients.php
@@ -27,6 +27,10 @@ if($_GET['sort'] == 1){
     $query = "clients_verification_status=0 and clients_status!=3"; 
     $sort_name = "Не верифицированные";                         
 }
+elseif ($_GET['sort'] == 7){
+    $query = 'clients_status=4';
+    $sort_name = 'Ожидают';
+}
            
 $url[] = 'sort='.$_GET['sort'];
 
@@ -92,6 +96,7 @@ $LINK = "?".implode("&",$url);
       <a class="dropdown-item" href="?route=clients&sort=3">Заблокированные</a>
       <a class="dropdown-item" href="?route=clients&sort=5">Верифицированные</a>
       <a class="dropdown-item" href="?route=clients&sort=6">Не верифицированные</a>
+      <a class="dropdown-item" href="?route=clients&sort=7">Ожидают</a>
     </div>
    </div>
  </div>
@@ -205,6 +210,15 @@ $LINK = "?".implode("&",$url);
 
                                         <?php
 
+                                     }elseif($value["clients_status"] == 4){
+                                        ?>
+                                        <button class="btn btn-info dropdown-toggle btn-sm" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                                          Ожидает
+                                        </button>
+                                        <div class="dropdown-menu" >
+                                          <a class="dropdown-item change-status-user" data-id="<?php echo $value["clients_id"]; ?>" data-status="1" href="#">Активировать</a>
+                                        </div>
+                                        <?php
                                      }elseif($value["clients_status"] == 3){
 
                                         ?>

--- a/cp_684cb2e048560/include/modules/clients/handlers/add.php
+++ b/cp_684cb2e048560/include/modules/clients/handlers/add.php
@@ -55,7 +55,7 @@ if (!$error) {
     $notifications = '{"messages":"1","answer_comments":"1","services":"1"}';
 
     $insert = insert("INSERT INTO uni_clients(clients_name,clients_surname,clients_pass,clients_email,clients_phone,clients_avatar,clients_status,clients_city_id,clients_datetime_add,clients_datetime_view,clients_id_hash,clients_notifications,clients_ref_id,clients_verification_code)
-                    VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?)", array($_POST['user_name'],$_POST['user_surname'],$password,$_POST['user_email'],$phone, $image["name"],1,intval($_POST["city_id"]), date("Y-m-d H:i:s"), date("Y-m-d H:i:s"),$clients_id_hash,$notifications,genRefId(),genVerificationCode()));    
+                    VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?)", array($_POST['user_name'],$_POST['user_surname'],$password,$_POST['user_email'],$phone, $image["name"],4,intval($_POST["city_id"]), date("Y-m-d H:i:s"), date("Y-m-d H:i:s"),$clients_id_hash,$notifications,genRefId(),genVerificationCode()));    
     
     echo json_encode(array("status" => true, "id" => $insert ));
 

--- a/cp_684cb2e048560/include/modules/clients/view.php
+++ b/cp_684cb2e048560/include/modules/clients/view.php
@@ -160,6 +160,15 @@ $data["requisites_company"] = $getUser['clients_requisites_company'] ? json_deco
 
                                   <?php
 
+                               }elseif($getUser["clients_status"] == 4){
+                                  ?>
+                                  <button class="btn btn-info dropdown-toggle btn-sm" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                                    Ожидает
+                                  </button>
+                                  <div class="dropdown-menu" >
+                                    <a class="dropdown-item change-status-user" data-id="<?php echo $getUser["clients_id"]; ?>" data-status="1" href="#">Активировать</a>
+                                  </div>
+                                  <?php
                                }elseif($getUser["clients_status"] == 3){
 
                                   ?>

--- a/migrations/001_add_pending_clients_status.sql
+++ b/migrations/001_add_pending_clients_status.sql
@@ -1,0 +1,5 @@
+-- Add pending status (value=4) to clients_status
+-- This migration does not alter table structure but documents new status
+-- Use this to ensure database defaults if needed
+ALTER TABLE `uni_clients`
+  MODIFY `clients_status` int(11) NOT NULL DEFAULT 4 COMMENT '0=unconfirmed,1=active,2=blocked,3=deleted,4=pending';

--- a/systems/ajax/profile/check_auth.php
+++ b/systems/ajax/profile/check_auth.php
@@ -79,7 +79,7 @@ if(!$error){
  
  if($getUser){
 
-       if($getUser->clients_status == 2 || $getUser->clients_status == 3){
+       if($getUser->clients_status == 2 || $getUser->clients_status == 3 || $getUser->clients_status == 4){
              
          $_SESSION["auth_captcha"]["count"]++;
          echo json_encode( array( "status" => false, "status_user" => $getUser->clients_status, "captcha"=>$_SESSION["auth_captcha"]["status"] ) );

--- a/systems/api/profile/auth/auth.php
+++ b/systems/api/profile/auth/auth.php
@@ -63,7 +63,7 @@ if(!count($errors)){
 
      if($getUser){
 
-           if($getUser->clients_status == 2 || $getUser->clients_status == 3){
+           if($getUser->clients_status == 2 || $getUser->clients_status == 3 || $getUser->clients_status == 4){
                  
              echo json_encode(["status"=>false, "errors" => apiLangContent("Ваш аккаунт заблокирован!")]);
 

--- a/systems/api/profile/auth/recovery.php
+++ b/systems/api/profile/auth/recovery.php
@@ -37,7 +37,7 @@ if(!count($errors)){
 
      if($getUser){
 
-           if($getUser->clients_status == 2 || $getUser->clients_status == 3){
+           if($getUser->clients_status == 2 || $getUser->clients_status == 3 || $getUser->clients_status == 4){
                  
              echo json_encode(["status"=>false, "errors" => apiLangContent("Ваш аккаунт заблокирован!")]);
 

--- a/systems/classes/Elastic.php
+++ b/systems/classes/Elastic.php
@@ -122,7 +122,7 @@ class Elastic{
               "filter": [ 
                 { "term":  { "ads_status": "1" }},
                 '.$term.'
-                { "terms":  { "clients_status": [0,1] }},
+                { "terms":  { "clients_status": [1] }},
                 { "range": { "ads_period_publication": { "gte": "now" }}}
               ]
             }
@@ -142,7 +142,7 @@ class Elastic{
             "bool": {  
               "filter": [ 
                 { "term":  { "ads_status": "1" }},
-                { "terms":  { "clients_status": [0,1] }},
+                { "terms":  { "clients_status": [1] }},
                 { "range": { "ads_period_publication": { "gte": "now" }}}
               ]
             }

--- a/systems/classes/Profile.php
+++ b/systems/classes/Profile.php
@@ -123,7 +123,7 @@ class Profile{
 
          $_SESSION['profile']['id'] = $get->clients_id;
 
-         if($get->clients_status == 2 || $get->clients_status == 3){
+         if($get->clients_status == 2 || $get->clients_status == 3 || $get->clients_status == 4){
            update('update uni_clients set clients_cookie_token=? where clients_id=?',['',$get->clients_id]);
            unset($_SESSION['profile']); 
            setcookie("tokenAuth", "", time() - 2592000);
@@ -748,7 +748,7 @@ class Profile{
 
        if($getUser){
 
-           if($getUser->clients_status == 2 || $getUser->clients_status == 3){
+           if($getUser->clients_status == 2 || $getUser->clients_status == 3 || $getUser->clients_status == 4){
                  
                return array( "status" => false, "status_user" => $getUser->clients_status );
 
@@ -772,7 +772,7 @@ class Profile{
 
        if($getUser){
              
-             if($getUser->clients_status == 2 || $getUser->clients_status == 3){
+             if($getUser->clients_status == 2 || $getUser->clients_status == 3 || $getUser->clients_status == 4){
                    
                  return array( "status" => false, "status_user" => $getUser->clients_status );
 


### PR DESCRIPTION
## Summary
- allow `pending` client status in database
- assign pending status on admin-created users
- filter and display pending users in admin section
- exclude unapproved users from search
- restrict login/search for pending accounts

## Testing
- `php` lint *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_685870f58e9c8332b0cc2369e72b5837