### PR TITLE
Adjust search filters for active and verified profiles

### DIFF
--- a/cp_684cb2e048560/include/modules/board/feed.php
+++ b/cp_684cb2e048560/include/modules/board/feed.php
@@ -37,7 +37,7 @@ $_GET["output"] = $_GET["output"] ? intval($_GET["output"]) : 50;
 
 if($_GET["status"] != "all"){
   if($_GET["status"] == 1){
-  	 $query[] = "clients_status IN(0,1) and ads_period_publication > now() and ads_status='1'";
+  	 $query[] = "(clients_status=1 or clients_verification_status=1) and ads_period_publication > now() and ads_status='1'";
   }else{
   	 $query[] = "ads_status='".intval($_GET["status"])."'";
   }

--- a/route/ad_update.php
+++ b/route/ad_update.php
@@ -32,7 +32,7 @@ if( $_SESSION['cp_control_board'] ){
 
 }else{
 
-   $data = $Ads->get("ads_id='$id_ad' and ads_id_user='".intval($_SESSION["profile"]["id"])."' and clients_status IN(0,1) and ads_status IN(0,7,2,1)");
+   $data = $Ads->get("ads_id='$id_ad' and ads_id_user='".intval($_SESSION["profile"]["id"])."' and (clients_status=1 or clients_verification_status=1) and ads_status IN(0,7,2,1)");
 
 }
 

--- a/route/catalog.php
+++ b/route/catalog.php
@@ -138,9 +138,9 @@ $data["city_metro"] = getAll("select * from uni_metro where city_id=? and parent
 
 if($data["category"]){
    $ids_cat = idsBuildJoin($CategoryBoard->idsBuild($data["category"]["category_board_id"], $getCategoryBoard), $data["category"]["category_board_id"]);
-   $data["vip"] = $Ads->getAll( ["query"=>"ads_status='1' and clients_status IN(0,1) and ads_period_publication > now() and ads_vip='1' and ads_id_cat IN(".$ids_cat.") $geo order by rand() limit 16", "param_search" => $param_search, "output" => 16 ] );
+   $data["vip"] = $Ads->getAll( ["query"=>"ads_status='1' and (clients_status=1 or clients_verification_status=1) and ads_period_publication > now() and ads_vip='1' and ads_id_cat IN(".$ids_cat.") $geo order by rand() limit 16", "param_search" => $param_search, "output" => 16 ] );
 }else{
-   $data["vip"] = $Ads->getAll( ["query"=>"ads_status='1' and clients_status IN(0,1) and ads_period_publication > now() and ads_vip='1' $geo order by rand() limit 16", "param_search" => $param_search, "output" => 16 ] );
+   $data["vip"] = $Ads->getAll( ["query"=>"ads_status='1' and (clients_status=1 or clients_verification_status=1) and ads_period_publication > now() and ads_vip='1' $geo order by rand() limit 16", "param_search" => $param_search, "output" => 16 ] );
 }
 
 if($_SESSION["geo"]["alias"]){

--- a/route/shop.php
+++ b/route/shop.php
@@ -93,7 +93,7 @@ if( $data["current_page"] ){
 
 $data["shop_count_subscriptions"] = (int)getOne("select count(*) as total from uni_clients_subscriptions where clients_subscriptions_id_user_to=?", [ intval($data["shop"]["clients_shops_id_user"]) ])["total"];
 
-$data["shop_count_ads"] = $Ads->getCount( "ads_status='1' and clients_status IN(0,1) and ads_period_publication > now() and ads_id_user='{$data["shop"]["clients_shops_id_user"]}'" );
+$data["shop_count_ads"] = $Ads->getCount( "ads_status='1' and (clients_status=1 or clients_verification_status=1) and ads_period_publication > now() and ads_id_user='{$data["shop"]["clients_shops_id_user"]}'" );
 $data["shop_sliders"] = getAll("select * from uni_clients_shops_slider where clients_shops_slider_id_shop=?", [ $data["shop"]["clients_shops_id"] ]);
 
 $data["shop_subscribers"] = getAll("select * from uni_clients_subscriptions where clients_subscriptions_id_shop=?", [ $data["shop"]["clients_shops_id"] ]);

--- a/rss.php
+++ b/rss.php
@@ -119,7 +119,7 @@ if( $content == "blog" ){
 
 }elseif( $content == "ads" ){
 
-	$query = "ads_status='1' and clients_status IN(0,1) and ads_period_publication > now()";
+	$query = "ads_status='1' and (clients_status=1 or clients_verification_status=1) and ads_period_publication > now()";
 	
 	if( $sort == "news" ){
         $sort = 'ORDER By ads_id DESC';

--- a/systems/ajax/ads/ad_similar.php
+++ b/systems/ajax/ads/ad_similar.php
@@ -22,7 +22,7 @@ if($id_ad && $id_cat && $settings["ad_similar_count"]){
   $param_search["query"]["bool"]["filter"][]["terms"]["ads_id_cat"] = explode(",", $ids_cat);
   $param_search["sort"]["ads_sorting"] = [ "order" => "desc" ];
 
-  $data["similar"] = $Ads->getAll( [ "query" => "ads_id_cat IN(".$ids_cat.") and clients_status IN(0,1) and ads_status='1' and ads_period_publication > now() and ads_id!=".$id_ad." {$ads_id_user} order by ads_sorting desc limit " . $settings["ad_similar_count"], "param_search" => $param_search, "output" => $settings["ad_similar_count"] ] );
+  $data["similar"] = $Ads->getAll( [ "query" => "ads_id_cat IN(".$ids_cat.") and (clients_status=1 or clients_verification_status=1) and ads_status='1' and ads_period_publication > now() and ads_id!=".$id_ad." {$ads_id_user} order by ads_sorting desc limit " . $settings["ad_similar_count"], "param_search" => $param_search, "output" => $settings["ad_similar_count"] ] );
 
    if($data["similar"]["all"]){
 

--- a/systems/ajax/ads/ads_search.php
+++ b/systems/ajax/ads/ads_search.php
@@ -120,7 +120,7 @@ if($page != 'shops'){
 
    }else{
 
-       $results = $Ads->getAll( array("navigation"=>false,"output"=>30,"query"=>"ads_status='1' and clients_status IN(0,1) and ads_period_publication > now() and ".$Filters->explodeSearch($query), "sort"=>"ORDER By ads_datetime_add DESC limit 30", "param_search" => $Elastic->paramAdSearch($query)));
+       $results = $Ads->getAll( array("navigation"=>false,"output"=>30,"query"=>"ads_status='1' and (clients_status=1 or clients_verification_status=1) and ads_period_publication > now() and ".$Filters->explodeSearch($query), "sort"=>"ORDER By ads_datetime_add DESC limit 30", "param_search" => $Elastic->paramAdSearch($query)));
 
        if($results["count"]){
 
@@ -153,7 +153,7 @@ if($settings["user_shop_status"]){
 if($page == 'shop'){
 
    if($getShop){
-       $results = $Ads->getAll( array("navigation"=>false,"output"=>10,"query"=>"ads_status='1' and clients_status IN(0,1) and ads_period_publication > now() and ads_id_user='".$getShop["clients_shops_id_user"]."' and ".$Filters->explodeSearch($query), "sort"=>"ORDER By ads_datetime_add DESC limit 10", "param_search" => $Elastic->paramAdSearch($query,$getShop["clients_shops_id_user"])));
+       $results = $Ads->getAll( array("navigation"=>false,"output"=>10,"query"=>"ads_status='1' and (clients_status=1 or clients_verification_status=1) and ads_period_publication > now() and ads_id_user='".$getShop["clients_shops_id_user"]."' and ".$Filters->explodeSearch($query), "sort"=>"ORDER By ads_datetime_add DESC limit 10", "param_search" => $Elastic->paramAdSearch($query,$getShop["clients_shops_id_user"])));
 
        if($results["count"]){
 
@@ -195,7 +195,7 @@ if($page == 'shop'){
         <div class="search-store-offers" >
         <?php
             foreach ($getShops as $key => $value) {
-               $count_ads = $Ads->getCount("ads_status='1' and clients_status IN(0,1) and ads_period_publication > now() and ads_id_user='{$value["clients_shops_id_user"]}'");
+               $count_ads = $Ads->getCount("ads_status='1' and (clients_status=1 or clients_verification_status=1) and ads_period_publication > now() and ads_id_user='{$value["clients_shops_id_user"]}'");
                ?>
                   <a href="<?php echo $Shop->linkShop($value["clients_shops_id_hash"]); ?>" > 
                     <div class="main-search-results-img" ><img src="<?php echo Exists($config["media"]["other"], $value["clients_shops_logo"], $config["media"]["no_image"]); ?>"></div>

--- a/systems/ajax/ads/load_catalog_ads.php
+++ b/systems/ajax/ads/load_catalog_ads.php
@@ -28,7 +28,7 @@ if( $query ){
      }
   }
 
-  $results = $Ads->getAll( array( "query"=>"ads_status='1' and clients_status IN(0,1) and ads_period_publication > now() $geoQuery and " . $Filters->explodeSearch($query) . " " .$sorting, "navigation"=>true, "output"=>$output, "page"=>$page, "param_search" => $param_search ) );
+  $results = $Ads->getAll( array( "query"=>"ads_status='1' and (clients_status=1 or clients_verification_status=1) and ads_period_publication > now() $geoQuery and " . $Filters->explodeSearch($query) . " " .$sorting, "navigation"=>true, "output"=>$output, "page"=>$page, "param_search" => $param_search ) );
   
 }else{
 

--- a/systems/ajax/ads/load_index_ads.php
+++ b/systems/ajax/ads/load_index_ads.php
@@ -80,7 +80,7 @@ if($ad_ids_interests){
 
 if($settings["index_out_content_method"] == 0){
 
-    $results = $Ads->getAll( ["sort"=>$sorting, "query"=>"ads_status='1' and clients_status IN(0,1) and ads_period_publication > now() $query", "navigation" => true, "page" => $page, "output" => $settings["index_out_content"], "param_search" => $param_search ] );
+    $results = $Ads->getAll( ["sort"=>$sorting, "query"=>"ads_status='1' and (clients_status=1 or clients_verification_status=1) and ads_period_publication > now() $query", "navigation" => true, "page" => $page, "output" => $settings["index_out_content"], "param_search" => $param_search ] );
 
 }else{
 
@@ -88,7 +88,7 @@ if($settings["index_out_content_method"] == 0){
         $geo = $Ads->queryGeo() ? " and " . $Ads->queryGeo() : "";
     }
 
-    $results = $Ads->getAll( ["sort"=>$sorting, "query"=>"ads_status='1' and clients_status IN(0,1) and ads_period_publication > now() $query $geo", "navigation" => true, "page" => $page, "output" => $settings["index_out_content"], "param_search" => $param_search ] );
+    $results = $Ads->getAll( ["sort"=>$sorting, "query"=>"ads_status='1' and (clients_status=1 or clients_verification_status=1) and ads_period_publication > now() $query $geo", "navigation" => true, "page" => $page, "output" => $settings["index_out_content"], "param_search" => $param_search ] );
 
 }
 

--- a/systems/ajax/ads/load_points_map.php
+++ b/systems/ajax/ads/load_points_map.php
@@ -18,7 +18,7 @@ if($_POST['search']){
 	    $geoQuery = $geoQuery ? ' and ' . $geoQuery : '';
 	}
 
-    $result = $Ads->getAll(array("query"=>"ads_status='1' and clients_status IN(0,1) and ads_period_publication > now() $geoQuery and " . $Filters->explodeSearch($query), "navigation"=>true, "page"=>$_POST['page'], "output"=>2000));
+    $result = $Ads->getAll(array("query"=>"ads_status='1' and (clients_status=1 or clients_verification_status=1) and ads_period_publication > now() $geoQuery and " . $Filters->explodeSearch($query), "navigation"=>true, "page"=>$_POST['page'], "output"=>2000));
 
 }else{
 

--- a/systems/ajax/shop/load_shop_ads.php
+++ b/systems/ajax/shop/load_shop_ads.php
@@ -9,7 +9,7 @@ $param_search["sort"]["ads_sorting"] = [ "order" => "desc" ];
 
 if( $query ){
 
-  $results = $Ads->getAll( array( "query"=>"ads_status='1' and clients_status IN(0,1) and ads_period_publication > now() and ads_id_user='{$id_user}' and " . $Filters->explodeSearch( $query ), "navigation"=>true, "page"=>$page, "param_search" => $param_search ) );
+  $results = $Ads->getAll( array( "query"=>"ads_status='1' and (clients_status=1 or clients_verification_status=1) and ads_period_publication > now() and ads_id_user='{$id_user}' and " . $Filters->explodeSearch( $query ), "navigation"=>true, "page"=>$page, "param_search" => $param_search ) );
   
 }else{
 

--- a/systems/ajax/shop/shops_load.php
+++ b/systems/ajax/shop/shops_load.php
@@ -7,8 +7,8 @@ if($id_c){
    $query = " and ( clients_shops_id_theme_category='{$id_c}' or clients_shops_id_theme_category='0' )";
 }
 
-$count = (int)getOne("select count(*) as total from uni_clients_shops INNER JOIN `uni_clients` ON `uni_clients`.clients_id = `uni_clients_shops`.clients_shops_id_user where (clients_shops_time_validity > now() or clients_shops_time_validity IS NULL) and clients_shops_status=1 and clients_status IN(0,1) {$query}")["total"];
-$results = getAll( "select * from uni_clients_shops INNER JOIN `uni_clients` ON `uni_clients`.clients_id = `uni_clients_shops`.clients_shops_id_user where (clients_shops_time_validity > now() or clients_shops_time_validity IS NULL) and clients_shops_status=1 and clients_status IN(0,1) {$query} order by clients_shops_id desc" . navigation_offset( array( "count"=>$count, "output"=>$settings["shops_out_content"], "page"=>$page ) ) );
+$count = (int)getOne("select count(*) as total from uni_clients_shops INNER JOIN `uni_clients` ON `uni_clients`.clients_id = `uni_clients_shops`.clients_shops_id_user where (clients_shops_time_validity > now() or clients_shops_time_validity IS NULL) and clients_shops_status=1 and (clients_status=1 or clients_verification_status=1) {$query}")["total"];
+$results = getAll( "select * from uni_clients_shops INNER JOIN `uni_clients` ON `uni_clients`.clients_id = `uni_clients_shops`.clients_shops_id_user where (clients_shops_time_validity > now() or clients_shops_time_validity IS NULL) and clients_shops_status=1 and (clients_status=1 or clients_verification_status=1) {$query} order by clients_shops_id desc" . navigation_offset( array( "count"=>$count, "output"=>$settings["shops_out_content"], "page"=>$page ) ) );
 
 if($results){
 

--- a/systems/api/ads/getAds.php
+++ b/systems/api/ads/getAds.php
@@ -63,7 +63,7 @@ if($filterIdUser){
       $sorting = "order by ads_sorting desc";
     }
 
-		$query[] = "clients_status IN(0,1) and ads_status='1' and ads_period_publication > now() and ads_id_user='".$filterIdUser."'";
+		$query[] = "(clients_status=1 or clients_verification_status=1) and ads_status='1' and ads_period_publication > now() and ads_id_user='".$filterIdUser."'";
 
 		$getAds = $Ads->getAll(["navigation"=>true,"page"=>$page,"output"=>$output,"query"=>implode(' and ', $query), "sort"=>$sorting]);
 
@@ -139,7 +139,7 @@ if($filterIdUser){
 		$query[] = "ads_auction='1'";
 	}
 
-	$query[] = "clients_status IN(0,1) and ads_status='1' and ads_period_publication > now()";
+	$query[] = "(clients_status=1 or clients_verification_status=1) and ads_status='1' and ads_period_publication > now()";
 
 	$getAds = $Ads->getAll(["navigation"=>true,"page"=>$page,"output"=>$output,"query"=>implode(' and ', $query), "sort"=>$sorting]);
 

--- a/systems/api/ads/searchAds.php
+++ b/systems/api/ads/searchAds.php
@@ -10,7 +10,7 @@ if($user_id){
 
   if(mb_strlen($query, 'UTF-8') >= 2){
 
-      $getAds = $Ads->getAll(["query"=>"ads_status!='8' and clients_status IN(0,1) and ads_id_user=".$user_id." and ".$Filters->explodeSearch($query), "sort"=>"ORDER By ads_datetime_add DESC limit 100"]);
+      $getAds = $Ads->getAll(["query"=>"ads_status!='8' and (clients_status=1 or clients_verification_status=1) and ads_id_user=".$user_id." and ".$Filters->explodeSearch($query), "sort"=>"ORDER By ads_datetime_add DESC limit 100"]);
 
       if($getAds["count"]){
 
@@ -25,7 +25,7 @@ if($user_id){
 
   }else{
 
-      $getAds = $Ads->getAll(["query"=>"ads_status!='8' and clients_status IN(0,1) and ads_id_user=".$user_id, "sort"=>"ORDER By ads_datetime_add DESC limit 5"]);
+      $getAds = $Ads->getAll(["query"=>"ads_status!='8' and (clients_status=1 or clients_verification_status=1) and ads_id_user=".$user_id, "sort"=>"ORDER By ads_datetime_add DESC limit 5"]);
 
       if($getAds["count"]){
 

--- a/systems/api/card_ad/getSimilarAds.php
+++ b/systems/api/card_ad/getSimilarAds.php
@@ -16,10 +16,10 @@ if(!$getAd){
 $getTariff = $Profile->getOrderTariff($getAd["ads_id_user"]);
 
 if($getTariff['services']['hiding_competitors_ads']){
-    $getAds = $Ads->getAll(["query" => "ads_id_cat IN(".idsBuildJoin($CategoryBoard->idsBuild($getAd["ads_id_cat"],$CategoryBoard->getCategories()),$getAd["ads_id_cat"]).") and clients_status IN(0,1) and ads_status='1' and ads_period_publication > now() and ads_id!='".$getAd['ads_id']."' and ads_id_user='".$getAd["ads_id_user"]."' order by ads_sorting desc limit 15", "output" => $output]);
+    $getAds = $Ads->getAll(["query" => "ads_id_cat IN(".idsBuildJoin($CategoryBoard->idsBuild($getAd["ads_id_cat"],$CategoryBoard->getCategories()),$getAd["ads_id_cat"]).") and (clients_status=1 or clients_verification_status=1) and ads_status='1' and ads_period_publication > now() and ads_id!='".$getAd['ads_id']."' and ads_id_user='".$getAd["ads_id_user"]."' order by ads_sorting desc limit 15", "output" => $output]);
     $title = apiLangContent('Другие объявления продавца');
 }else{
-	$getAds = $Ads->getAll(["query" => "ads_id_cat IN(".idsBuildJoin($CategoryBoard->idsBuild($getAd["ads_id_cat"],$CategoryBoard->getCategories()),$getAd["ads_id_cat"]).") and clients_status IN(0,1) and ads_status='1' and ads_period_publication > now() and ads_id!='".$getAd['ads_id']."' order by ads_sorting desc limit $output", "output" => $output]);
+	$getAds = $Ads->getAll(["query" => "ads_id_cat IN(".idsBuildJoin($CategoryBoard->idsBuild($getAd["ads_id_cat"],$CategoryBoard->getCategories()),$getAd["ads_id_cat"]).") and (clients_status=1 or clients_verification_status=1) and ads_status='1' and ads_period_publication > now() and ads_id!='".$getAd['ads_id']."' order by ads_sorting desc limit $output", "output" => $output]);
     $title = apiLangContent('Похожие объявления');
 }
 

--- a/systems/api/catalog/getAds.php
+++ b/systems/api/catalog/getAds.php
@@ -76,7 +76,7 @@ if($sorting == 'default'){
     
 }
 
-$query[] = "clients_status IN(0,1) and ads_status='1' and ads_period_publication > now()";
+$query[] = "(clients_status=1 or clients_verification_status=1) and ads_status='1' and ads_period_publication > now()";
 
 if(!$only_ids){
 

--- a/systems/api/catalog/getCategoriesOffers.php
+++ b/systems/api/catalog/getCategoriesOffers.php
@@ -24,7 +24,7 @@ if($idUser){
 			$viewAds[] = $value["ads_id"];
 		}
 
-		$getAds = $Ads->getAll(["query"=>"ads_status='1' and clients_status IN(0,1) and ads_period_publication > now() and ads_id IN(".implode(",", $viewAds).")"]);
+		$getAds = $Ads->getAll(["query"=>"ads_status='1' and (clients_status=1 or clients_verification_status=1) and ads_period_publication > now() and ads_id IN(".implode(",", $viewAds).")"]);
 
 	    $results['ads'] = apiArrayDataAds($getAds,$idUser); 
 
@@ -40,7 +40,7 @@ if($idUser){
 			$favoritesAds[] = $value["favorites_id_ad"];
 		}
 
-		$getAds = $Ads->getAll(["query"=>"ads_status='1' and clients_status IN(0,1) and ads_period_publication > now() and ads_id IN(".implode(",", $favoritesAds).")"]);
+		$getAds = $Ads->getAll(["query"=>"ads_status='1' and (clients_status=1 or clients_verification_status=1) and ads_period_publication > now() and ads_id IN(".implode(",", $favoritesAds).")"]);
 
 	    $results['favorites'] = apiArrayDataAds($getAds,$idUser); 
 

--- a/systems/api/catalog/search.php
+++ b/systems/api/catalog/search.php
@@ -117,7 +117,7 @@ if(mb_strlen($query, 'UTF-8') >= 2){
 
 	// Ads
 
-   $getAds = $Ads->getAll(["query"=>"ads_status='1' and clients_status IN(0,1) and ads_period_publication > now() and ".$Filters->explodeSearch(clearSearchBack($_GET["query"])).$queryGeo, "sort"=>"ORDER By ads_datetime_add DESC limit 5"]);
+   $getAds = $Ads->getAll(["query"=>"ads_status='1' and (clients_status=1 or clients_verification_status=1) and ads_period_publication > now() and ".$Filters->explodeSearch(clearSearchBack($_GET["query"])).$queryGeo, "sort"=>"ORDER By ads_datetime_add DESC limit 5"]);
 
    if($getAds["count"]){
 

--- a/systems/api/catalog/searchAdsShop.php
+++ b/systems/api/catalog/searchAdsShop.php
@@ -10,7 +10,7 @@ $getShop = findOne("uni_clients_shops", "clients_shops_id=?", [$shop_id]);
 
 if(mb_strlen($query, 'UTF-8') >= 2 && $getShop){
 
-    $getAds = $Ads->getAll(["query"=>"ads_status='1' and clients_status IN(0,1) and ads_period_publication > now() and ads_id_user=".$getShop["clients_shops_id_user"]." and ".$Filters->explodeSearch($query), "sort"=>"ORDER By ads_datetime_add DESC limit 100"]);
+    $getAds = $Ads->getAll(["query"=>"ads_status='1' and (clients_status=1 or clients_verification_status=1) and ads_period_publication > now() and ads_id_user=".$getShop["clients_shops_id_user"]." and ".$Filters->explodeSearch($query), "sort"=>"ORDER By ads_datetime_add DESC limit 100"]);
 
     if($getAds["count"]){
 

--- a/systems/api/fn.php
+++ b/systems/api/fn.php
@@ -1709,7 +1709,7 @@ function apiViewAds($id = 0, $id_user = 0, $ip = ""){
                 $sliders = [];
                 $ads_images = [];
 
-                $getCountAds = $Ads->getCount("ads_status='1' and clients_status IN(0,1) and ads_period_publication > now() and ads_id_user='".$value["clients_shops_id_user"]."'");
+                $getCountAds = $Ads->getCount("ads_status='1' and (clients_status=1 or clients_verification_status=1) and ads_period_publication > now() and ads_id_user='".$value["clients_shops_id_user"]."'");
                 $getUser = findOne('uni_clients', 'clients_id=?', [$value['clients_shops_id_user']]);
                 $getSliders = getAll("select * from uni_clients_shops_slider where clients_shops_slider_id_shop=?", [$value["clients_shops_id"]]);
 

--- a/systems/api/home/getFeed.php
+++ b/systems/api/home/getFeed.php
@@ -23,7 +23,7 @@ if(count($getFeeds)){
 
     	if($value['feed_stories_action'] == 'new_ads'){
 
-    		$getAds = $Ads->getAll(["query"=>"ads_id IN(".implode(',',$data['ids']).") and ads_status='1' and clients_status IN(0,1) and ads_period_publication > now()"]);
+    		$getAds = $Ads->getAll(["query"=>"ads_id IN(".implode(',',$data['ids']).") and ads_status='1' and (clients_status=1 or clients_verification_status=1) and ads_period_publication > now()"]);
 
     		if($getAds['count']){
 
@@ -135,7 +135,7 @@ if(count($getFeeds)){
 
     	}elseif($value['feed_stories_action'] == 'services_ad'){
 
-    		$getAd = $Ads->get("ads_id=? and ads_status=? and clients_status IN(0,1) and ads_period_publication > now()", [$data['id'],1]);
+    		$getAd = $Ads->get("ads_id=? and ads_status=? and (clients_status=1 or clients_verification_status=1) and ads_period_publication > now()", [$data['id'],1]);
 
     		if($getAd){
 

--- a/systems/api/profile/favorites/getFavoritesSubscriptions.php
+++ b/systems/api/profile/favorites/getFavoritesSubscriptions.php
@@ -32,7 +32,7 @@ if($getViewAds){
 		$viewAds[] = $value["ads_id"];
 	}
 
-	$getAds = $Ads->getAll(["query"=>"ads_status='1' and clients_status IN(0,1) and ads_period_publication > now() and ads_id IN(".implode(",", $viewAds).")"]);
+	$getAds = $Ads->getAll(["query"=>"ads_status='1' and (clients_status=1 or clients_verification_status=1) and ads_period_publication > now() and ads_id IN(".implode(",", $viewAds).")"]);
 
     $viewed = apiArrayDataAds($getAds,$idUser); 
 

--- a/systems/api/shops/getShop.php
+++ b/systems/api/shops/getShop.php
@@ -46,7 +46,7 @@ if(count($getPages)){
 	}
 }
 
-$getCountAds = $Ads->getCount("ads_status='1' and clients_status IN(0,1) and ads_period_publication > now() and ads_id_user='".$getShop["clients_shops_id_user"]."'");
+$getCountAds = $Ads->getCount("ads_status='1' and (clients_status=1 or clients_verification_status=1) and ads_period_publication > now() and ads_id_user='".$getShop["clients_shops_id_user"]."'");
 $getSubscribers = (int)getOne("select count(*) as total from uni_clients_subscriptions where clients_subscriptions_id_user_to=?", [$getShop["clients_shops_id_user"]])["total"];
 $getInSubscribe = findOne('uni_clients_subscriptions', 'clients_subscriptions_id_user_from=? and clients_subscriptions_id_user_to=?', [$idUser,$getShop["clients_shops_id_user"]]);
 

--- a/systems/api/shops/getShops.php
+++ b/systems/api/shops/getShops.php
@@ -8,9 +8,9 @@ $ads_images = [];
 
 $query = "";
 
-$totalCount = (int)getOne("select count(*) as total from uni_clients_shops INNER JOIN `uni_clients` ON `uni_clients`.clients_id = `uni_clients_shops`.clients_shops_id_user where (clients_shops_time_validity > now() or clients_shops_time_validity IS NULL) and clients_shops_status=1 and clients_status IN(0,1) and clients_shops_id_theme_category!=0 {$query}")["total"];
+$totalCount = (int)getOne("select count(*) as total from uni_clients_shops INNER JOIN `uni_clients` ON `uni_clients`.clients_id = `uni_clients_shops`.clients_shops_id_user where (clients_shops_time_validity > now() or clients_shops_time_validity IS NULL) and clients_shops_status=1 and (clients_status=1 or clients_verification_status=1) and clients_shops_id_theme_category!=0 {$query}")["total"];
 
-$getShops = getAll("select * from uni_clients_shops INNER JOIN `uni_clients` ON `uni_clients`.clients_id = `uni_clients_shops`.clients_shops_id_user where (clients_shops_time_validity > now() or clients_shops_time_validity IS NULL) and clients_shops_status=1 and clients_status IN(0,1) and clients_shops_id_theme_category!=0 {$query} order by clients_shops_id desc".navigation_offset(["count"=>$totalCount, "output"=>$output, "page"=>$page]));
+$getShops = getAll("select * from uni_clients_shops INNER JOIN `uni_clients` ON `uni_clients`.clients_id = `uni_clients_shops`.clients_shops_id_user where (clients_shops_time_validity > now() or clients_shops_time_validity IS NULL) and clients_shops_status=1 and (clients_status=1 or clients_verification_status=1) and clients_shops_id_theme_category!=0 {$query} order by clients_shops_id desc".navigation_offset(["count"=>$totalCount, "output"=>$output, "page"=>$page]));
 
 echo json_encode(['data'=>apiArrayDataShops($getShops), 'count'=>$totalCount .' '.ending($totalCount, apiLangContent('магазин'), apiLangContent('магазина'), apiLangContent('магазинов')), 'pages'=>getCountPage($totalCount,$output)]);
 

--- a/systems/classes/CategoryBoard.php
+++ b/systems/classes/CategoryBoard.php
@@ -403,13 +403,13 @@ class CategoryBoard{
           }else{
 
              if($_SESSION["geo"]["data"]["city_id"]){
-                 $count = (int)getOne("select count(ads_id) as total from uni_ads INNER JOIN `uni_clients` ON `uni_clients`.clients_id = `uni_ads`.ads_id_user where ads_status='1' and clients_status IN(0,1) and ads_period_publication > now() and ads_id_cat IN(".implode(",", $idsBuildArray).") and ads_city_id=? and ads_id_user=?", [$_SESSION["geo"]["data"]["city_id"],$user_id])["total"];
+                 $count = (int)getOne("select count(ads_id) as total from uni_ads INNER JOIN `uni_clients` ON `uni_clients`.clients_id = `uni_ads`.ads_id_user where ads_status='1' and (clients_status=1 or clients_verification_status=1) and ads_period_publication > now() and ads_id_cat IN(".implode(",", $idsBuildArray).") and ads_city_id=? and ads_id_user=?", [$_SESSION["geo"]["data"]["city_id"],$user_id])["total"];
              }elseif($_SESSION["geo"]["data"]["region_id"]){
-                 $count = (int)getOne("select count(ads_id) as total from uni_ads INNER JOIN `uni_clients` ON `uni_clients`.clients_id = `uni_ads`.ads_id_user where ads_status='1' and clients_status IN(0,1) and ads_period_publication > now() and ads_id_cat IN(".implode(",", $idsBuildArray).") and ads_region_id=? and ads_id_user=?", [$_SESSION["geo"]["data"]["region_id"],$user_id])["total"];
+                 $count = (int)getOne("select count(ads_id) as total from uni_ads INNER JOIN `uni_clients` ON `uni_clients`.clients_id = `uni_ads`.ads_id_user where ads_status='1' and (clients_status=1 or clients_verification_status=1) and ads_period_publication > now() and ads_id_cat IN(".implode(",", $idsBuildArray).") and ads_region_id=? and ads_id_user=?", [$_SESSION["geo"]["data"]["region_id"],$user_id])["total"];
              }elseif($_SESSION["geo"]["data"]["country_id"]){
-                 $count = (int)getOne("select count(ads_id) as total from uni_ads INNER JOIN `uni_clients` ON `uni_clients`.clients_id = `uni_ads`.ads_id_user where ads_status='1' and clients_status IN(0,1) and ads_period_publication > now() and ads_id_cat IN(".implode(",", $idsBuildArray).") and ads_country_id=? and ads_id_user=?", [$_SESSION["geo"]["data"]["country_id"],$user_id])["total"];
+                 $count = (int)getOne("select count(ads_id) as total from uni_ads INNER JOIN `uni_clients` ON `uni_clients`.clients_id = `uni_ads`.ads_id_user where ads_status='1' and (clients_status=1 or clients_verification_status=1) and ads_period_publication > now() and ads_id_cat IN(".implode(",", $idsBuildArray).") and ads_country_id=? and ads_id_user=?", [$_SESSION["geo"]["data"]["country_id"],$user_id])["total"];
              }else{
-                 $count = (int)getOne("select count(ads_id) as total from uni_ads INNER JOIN `uni_clients` ON `uni_clients`.clients_id = `uni_ads`.ads_id_user where ads_status='1' and clients_status IN(0,1) and ads_period_publication > now() and ads_id_cat IN(".implode(",", $idsBuildArray).") and ads_id_user=?", [$user_id])["total"];
+                 $count = (int)getOne("select count(ads_id) as total from uni_ads INNER JOIN `uni_clients` ON `uni_clients`.clients_id = `uni_ads`.ads_id_user where ads_status='1' and (clients_status=1 or clients_verification_status=1) and ads_period_publication > now() and ads_id_cat IN(".implode(",", $idsBuildArray).") and ads_id_user=?", [$user_id])["total"];
              }
 
           }

--- a/systems/classes/Elastic.php
+++ b/systems/classes/Elastic.php
@@ -122,7 +122,14 @@ class Elastic{
               "filter": [ 
                 { "term":  { "ads_status": "1" }},
                 '.$term.'
-                { "terms":  { "clients_status": [0,1] }},
+                { "bool": {
+                    "should": [
+                        { "term": { "clients_status": "1" }},
+                        { "term": { "clients_verification_status": "1" }}
+                    ],
+                    "minimum_should_match": 1,
+                    "must_not": [ { "term": { "clients_status": "0" } } ]
+                  }},
                 { "range": { "ads_period_publication": { "gte": "now" }}}
               ]
             }
@@ -142,7 +149,14 @@ class Elastic{
             "bool": {  
               "filter": [ 
                 { "term":  { "ads_status": "1" }},
-                { "terms":  { "clients_status": [0,1] }},
+                { "bool": {
+                    "should": [
+                        { "term": { "clients_status": "1" }},
+                        { "term": { "clients_verification_status": "1" }}
+                    ],
+                    "minimum_should_match": 1,
+                    "must_not": [ { "term": { "clients_status": "0" } } ]
+                  }},
                 { "range": { "ads_period_publication": { "gte": "now" }}}
               ]
             }

--- a/systems/classes/Filters.php
+++ b/systems/classes/Filters.php
@@ -34,7 +34,7 @@ class Filters{
       $Main = new Main();
       $Elastic = new Elastic();
 
-      $binding_query = "ads_status='1' and clients_status IN(0,1) and ads_period_publication > now()";
+      $binding_query = "ads_status='1' and (clients_status=1 or clients_verification_status=1) and ads_period_publication > now()";
 
       $param_search = $Elastic->paramAdquery();
 

--- a/systems/classes/Main.php
+++ b/systems/classes/Main.php
@@ -959,7 +959,7 @@ class Main{
               $param_search["query"]["bool"]["filter"][]["term"] = $Ads->arrayGeo();
               $param_search["query"]["bool"]["filter"][]["terms"]["ads_id_cat"] = $list_cats;
               
-              $getAds = $Ads->getAll( ["query"=>"ads_status='1' and clients_status IN(0,1) and ads_period_publication > now() and ads_id_cat IN(".$list_cats.") $geo order by ads_id desc limit $output", "param_search" => $param_search, "output" => $output ] );
+              $getAds = $Ads->getAll( ["query"=>"ads_status='1' and (clients_status=1 or clients_verification_status=1) and ads_period_publication > now() and ads_id_cat IN(".$list_cats.") $geo order by ads_id desc limit $output", "param_search" => $param_search, "output" => $output ] );
               if( $getAds["count"] ){
                   
                   foreach ($getAds["all"] as $key => $value) {

--- a/systems/classes/Shop.php
+++ b/systems/classes/Shop.php
@@ -145,9 +145,9 @@ class Shop{
         $param_search["sort"]["ads_id"] = [ "order" => "desc" ];
 
         if( $param["limit"] ){
-            return $Ads->getAll( ["query"=>"ads_status='1' and clients_status IN(0,1) and ads_period_publication > now() and ads_id_user='{$param["id_user"]}'", "sort" => "order by ads_sorting desc, ads_id desc limit {$param["limit"]}", "param_search" => $param_search, "output" => $param["limit"] ] );
+            return $Ads->getAll( ["query"=>"ads_status='1' and (clients_status=1 or clients_verification_status=1) and ads_period_publication > now() and ads_id_user='{$param["id_user"]}'", "sort" => "order by ads_sorting desc, ads_id desc limit {$param["limit"]}", "param_search" => $param_search, "output" => $param["limit"] ] );
         }else{
-            return $Ads->getAll( ["query"=>"ads_status='1' and clients_status IN(0,1) and ads_period_publication > now() and ads_id_user='{$param["id_user"]}'", "sort" => "order by ads_sorting desc, ads_id desc", "navigation" => $param["navigation"], "param_search" => $param_search ] );
+            return $Ads->getAll( ["query"=>"ads_status='1' and (clients_status=1 or clients_verification_status=1) and ads_period_publication > now() and ads_id_user='{$param["id_user"]}'", "sort" => "order by ads_sorting desc, ads_id desc", "navigation" => $param["navigation"], "param_search" => $param_search ] );
         }
 
 

--- a/systems/cron/feed_stories.php
+++ b/systems/cron/feed_stories.php
@@ -60,7 +60,7 @@ shuffle($results);
 
 // Новые объявления
 
-$getAds = $Ads->getAll(["query"=>"ads_status='1' and clients_status IN(0,1) and ads_period_publication > now() and ads_datetime_add >= DATE_SUB(NOW() , INTERVAL 60 MINUTE)"]);
+$getAds = $Ads->getAll(["query"=>"ads_status='1' and (clients_status=1 or clients_verification_status=1) and ads_period_publication > now() and ads_datetime_add >= DATE_SUB(NOW() , INTERVAL 60 MINUTE)"]);
 
 if($getAds['count']){
   foreach ($getAds['all'] as $key => $value) {

--- a/systems/cron/notifications.php
+++ b/systems/cron/notifications.php
@@ -161,7 +161,7 @@ if( count($getClientsSubscriptions) ){
 
         if( $getShop && $value["clients_subscriptions_time_update"] ){
 
-            $results = $Ads->getAll( array( "query"=>"ads_status='1' and clients_status IN(0,1) and ads_period_publication > now() and ads_id_user='".$value["clients_subscriptions_id_user_to"]."' and ads_datetime_add > '".$value["clients_subscriptions_time_update"]."'" ) );
+            $results = $Ads->getAll( array( "query"=>"ads_status='1' and (clients_status=1 or clients_verification_status=1) and ads_period_publication > now() and ads_id_user='".$value["clients_subscriptions_id_user_to"]."' and ads_datetime_add > '".$value["clients_subscriptions_time_update"]."'" ) );
 
             if( $results["count"] ){
 

--- a/systems/cron/sitemap.php
+++ b/systems/cron/sitemap.php
@@ -44,7 +44,7 @@ if($settings["sitemap_seo_filters"]){
 
 if($settings["sitemap_alias_filters"] || $settings["sitemap_cities"]){
 
-   $getAds = getAll("select * from uni_ads INNER JOIN `uni_clients` ON `uni_clients`.clients_id = `uni_ads`.ads_id_user where ads_status='1' and clients_status IN(0,1) and ads_period_publication > now() group by ads_city_id");
+   $getAds = getAll("select * from uni_ads INNER JOIN `uni_clients` ON `uni_clients`.clients_id = `uni_ads`.ads_id_user where ads_status='1' and (clients_status=1 or clients_verification_status=1) and ads_period_publication > now() group by ads_city_id");
 
    if(count($getAds)){
       foreach ($getAds as $key => $ad_value) {
@@ -112,7 +112,7 @@ if($settings["sitemap_alias_filters"] || $settings["sitemap_cities"]){
 
 if($settings["sitemap_category"]){
 
-   $getAds = getAll("select * from uni_ads INNER JOIN `uni_clients` ON `uni_clients`.clients_id = `uni_ads`.ads_id_user where ads_status='1' and clients_status IN(0,1) and ads_period_publication > now() group by ads_id_cat");
+   $getAds = getAll("select * from uni_ads INNER JOIN `uni_clients` ON `uni_clients`.clients_id = `uni_ads`.ads_id_user where ads_status='1' and (clients_status=1 or clients_verification_status=1) and ads_period_publication > now() group by ads_id_cat");
 
    if(count($getAds)){
       foreach ($getAds as $key => $ad_value) {
@@ -186,7 +186,7 @@ if($settings["sitemap_blog_category"]){
 
 if($settings["sitemap_shops"]){
 
-   $getShops = getAll( "select * from uni_clients_shops INNER JOIN `uni_clients` ON `uni_clients`.clients_id = `uni_clients_shops`.clients_shops_id_user where clients_shops_time_validity > now() and clients_status IN(0,1) and clients_shops_status=?", [1]);
+   $getShops = getAll( "select * from uni_clients_shops INNER JOIN `uni_clients` ON `uni_clients`.clients_id = `uni_clients_shops`.clients_shops_id_user where clients_shops_time_validity > now() and (clients_status=1 or clients_verification_status=1) and clients_shops_status=?", [1]);
 
    if($getShops){
       foreach ($getShops as $value) {

--- a/systems/cron/sorting_ad.php
+++ b/systems/cron/sorting_ad.php
@@ -14,7 +14,7 @@ if(count($getOrderAd)){
 }
 
 if($data["ids"]){
-   $getAds = $Ads->getAll( array("query"=>"ads_status='1' and clients_status IN(0,1) and ads_period_publication > now() and ads_id IN(".implode(",",$data["ids"]).")", "sort"=>"order by ads_count_display desc", "navigation"=>false) );
+   $getAds = $Ads->getAll( array("query"=>"ads_status='1' and (clients_status=1 or clients_verification_status=1) and ads_period_publication > now() and ads_id IN(".implode(",",$data["ids"]).")", "sort"=>"order by ads_count_display desc", "navigation"=>false) );
    if($getAds["all"]){
       foreach ($getAds["all"] as $key => $value) {
 

--- a/systems/cron/update_count_ad.php
+++ b/systems/cron/update_count_ad.php
@@ -12,7 +12,7 @@ if($settings['display_count_ads_categories']){
 
       foreach ($getCategories as $value) {
 
-         $getAds = getAll("select * from uni_ads INNER JOIN `uni_clients` ON `uni_clients`.clients_id = `uni_ads`.ads_id_user where ads_status='1' and clients_status IN(0,1) and ads_period_publication > now() and ads_id_cat='".$value["category_board_id"]."'");
+         $getAds = getAll("select * from uni_ads INNER JOIN `uni_clients` ON `uni_clients`.clients_id = `uni_ads`.ads_id_user where ads_status='1' and (clients_status=1 or clients_verification_status=1) and ads_period_publication > now() and ads_id_cat='".$value["category_board_id"]."'");
 
          if($getAds){
             foreach ($getAds as $ad_value) {

--- a/templates/include/shop_grid.php
+++ b/templates/include/shop_grid.php
@@ -1,6 +1,6 @@
 <?php
 $ratings = $Profile->outRating( $value["clients_shops_id_user"] );
-$count_ads = $Ads->getCount("ads_status='1' and clients_status IN(0,1) and ads_period_publication > now() and ads_id_user='{$value["clients_id"]}'");
+$count_ads = $Ads->getCount("ads_status='1' and (clients_status=1 or clients_verification_status=1) and ads_period_publication > now() and ads_id_user='{$value["clients_id"]}'");
 $get_shop_slider = findOne('uni_clients_shops_slider','clients_shops_slider_id_shop=? order by clients_shops_slider_id asc', [$value["clients_shops_id"]]);
 ?>
 <div class="col-lg-3 col-md-4 col-sm-6 col-12" >

--- a/templates/include/shop_list.php
+++ b/templates/include/shop_list.php
@@ -1,6 +1,6 @@
 <?php
 $ratings = $Profile->outRating($value["clients_shops_id_user"]);
-$count_ads = $Ads->getCount("ads_status='1' and clients_status IN(0,1) and ads_period_publication > now() and ads_id_user='{$value["clients_id"]}'");
+$count_ads = $Ads->getCount("ads_status='1' and (clients_status=1 or clients_verification_status=1) and ads_period_publication > now() and ads_id_user='{$value["clients_id"]}'");
 $count_reviews = (int)getOne("select count(*) as total from uni_clients_reviews where clients_reviews_id_user=?", [$value["clients_id"]])["total"];
 $get_shop_slider = findOne('uni_clients_shops_slider','clients_shops_slider_id_shop=? order by clients_shops_slider_id asc', [$value["clients_shops_id"]]);
 ?>

--- a/templates/index.tpl
+++ b/templates/index.tpl
@@ -69,7 +69,7 @@
 
                 }elseif($widgetName == "shop" && $settings["home_shop_status"]){
 
-                    $data["shops"] = getAll("select * from uni_clients_shops INNER JOIN `uni_clients` ON `uni_clients`.clients_id = `uni_clients_shops`.clients_shops_id_user where (clients_shops_time_validity > now() or clients_shops_time_validity IS NULL) and clients_shops_status=1 and clients_status IN(0,1) order by rand() limit ?", [$settings["index_out_count_shops"] ?: 16]);
+                    $data["shops"] = getAll("select * from uni_clients_shops INNER JOIN `uni_clients` ON `uni_clients`.clients_id = `uni_clients_shops`.clients_shops_id_user where (clients_shops_time_validity > now() or clients_shops_time_validity IS NULL) and clients_shops_status=1 and (clients_status=1 or clients_verification_status=1) order by rand() limit ?", [$settings["index_out_count_shops"] ?: 16]);
 
                     if($data["shops"]){ ?>
                     <div class="mb25 title-and-link h3" > <strong><?php echo $ULang->t( "Магазины" ); ?></strong> <a href="<?php echo $Shop->linkShops(); ?>"><?php echo $ULang->t( "Все магазины" ); ?> <i class="las la-arrow-right"></i> </a> </div>
@@ -126,9 +126,9 @@
                     }
                     
                     if($settings["index_out_content_method"] == 0){
-                      $data["vip"] = $Ads->getAll( ["query"=>"ads_status='1' and clients_status IN(0,1) and ads_period_publication > now() and ads_vip='1' order by rand() limit 16", "param_search" => $param_search, "output" => 16 ] );
+                      $data["vip"] = $Ads->getAll( ["query"=>"ads_status='1' and (clients_status=1 or clients_verification_status=1) and ads_period_publication > now() and ads_vip='1' order by rand() limit 16", "param_search" => $param_search, "output" => 16 ] );
                     }else{
-                      $data["vip"] = $Ads->getAll( ["query"=>"ads_status='1' and clients_status IN(0,1) and ads_period_publication > now() and ads_vip='1' $geo order by rand() limit 16", "param_search" => $param_search, "output" => 16 ] );
+                      $data["vip"] = $Ads->getAll( ["query"=>"ads_status='1' and (clients_status=1 or clients_verification_status=1) and ads_period_publication > now() and ads_vip='1' $geo order by rand() limit 16", "param_search" => $param_search, "output" => 16 ] );
                     }
 
                     if($settings["main_type_products"] == 'physical'){
@@ -210,9 +210,9 @@
                     }
                     
                     if($settings["index_out_content_method"] == 0){
-                      $data["auction"] = $Ads->getAll( ["query"=>"ads_status='1' and clients_status IN(0,1) and ads_period_publication > now() and ads_auction='1' order by rand() limit 16", "output" => 16 ] );
+                      $data["auction"] = $Ads->getAll( ["query"=>"ads_status='1' and (clients_status=1 or clients_verification_status=1) and ads_period_publication > now() and ads_auction='1' order by rand() limit 16", "output" => 16 ] );
                     }else{
-                      $data["auction"] = $Ads->getAll( ["query"=>"ads_status='1' and clients_status IN(0,1) and ads_period_publication > now() and ads_auction='1' $geo order by rand() limit 16", "output" => 16 ] );
+                      $data["auction"] = $Ads->getAll( ["query"=>"ads_status='1' and (clients_status=1 or clients_verification_status=1) and ads_period_publication > now() and ads_auction='1' $geo order by rand() limit 16", "output" => 16 ] );
                     }
 
                     if($settings["main_type_products"] == 'physical'){

--- a/templates/shops.tpl
+++ b/templates/shops.tpl
@@ -71,7 +71,7 @@
                       if( $getCategoryBoard["category_board_id_parent"][0] ){
                           foreach ($getCategoryBoard["category_board_id_parent"][0] as $value) {
 
-                              $countShop = (int)getOne( 'select count(*) as total from uni_clients_shops INNER JOIN `uni_clients` ON `uni_clients`.clients_id = `uni_clients_shops`.clients_shops_id_user where (clients_shops_time_validity > now() or clients_shops_time_validity IS NULL) and clients_shops_status=1 and clients_status IN(0,1) and (clients_shops_id_theme_category=? or clients_shops_id_theme_category=?)', [ $value["category_board_id"], 0 ] )['total'];
+                              $countShop = (int)getOne( 'select count(*) as total from uni_clients_shops INNER JOIN `uni_clients` ON `uni_clients`.clients_id = `uni_clients_shops`.clients_shops_id_user where (clients_shops_time_validity > now() or clients_shops_time_validity IS NULL) and clients_shops_status=1 and (clients_status=1 or clients_verification_status=1) and (clients_shops_id_theme_category=? or clients_shops_id_theme_category=?)', [ $value["category_board_id"], 0 ] )['total'];
                               ?>
                               <li>
                                 <a <?php if( $value["category_board_id"] == $data["current_category"]["category_board_id"] ){ echo 'class="active"'; } ?> href="<?php echo $Shop->linkShopsCategory($value["category_board_chain"]); ?>"><?php echo $ULang->t( $value["category_board_name"], [ "table" => "uni_category_board", "field" => "category_board_name" ] ); ?><span class="shop-category-list-count" ><?php echo $countShop; ?></span></a>
@@ -116,7 +116,7 @@
                       if( $getCategoryBoard["category_board_id_parent"][0] ){
                           foreach ($getCategoryBoard["category_board_id_parent"][0] as $value) {
 
-                              $countShop = (int)getOne( 'select count(*) as total from uni_clients_shops INNER JOIN `uni_clients` ON `uni_clients`.clients_id = `uni_clients_shops`.clients_shops_id_user where (clients_shops_time_validity > now() or clients_shops_time_validity IS NULL) and clients_shops_status=1 and clients_status IN(0,1) and (clients_shops_id_theme_category=? or clients_shops_id_theme_category=?)', [ $value["category_board_id"], 0 ] )['total'];
+                              $countShop = (int)getOne( 'select count(*) as total from uni_clients_shops INNER JOIN `uni_clients` ON `uni_clients`.clients_id = `uni_clients_shops`.clients_shops_id_user where (clients_shops_time_validity > now() or clients_shops_time_validity IS NULL) and clients_shops_status=1 and (clients_status=1 or clients_verification_status=1) and (clients_shops_id_theme_category=? or clients_shops_id_theme_category=?)', [ $value["category_board_id"], 0 ] )['total'];
                               ?>
                               <li>
                                 <a <?php if($value["category_board_id"] == $data["current_category"]["category_board_id"]){ echo 'class="active"'; } ?> href="<?php echo $Shop->linkShopsCategory($value["category_board_chain"]); ?>"><?php echo $ULang->t($value["category_board_name"], [ "table" => "uni_category_board", "field" => "category_board_name" ]); ?><span class="shop-category-list-count" ><?php echo $countShop; ?></span></a>


### PR DESCRIPTION
## Summary
- broaden search logic to match either active or verified profiles
- exclude pending users from search results
- update ElasticSearch query builder

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_685877089854833285c7ac8db08a2715