### PR TITLE
Fix Elastic client property name

### DIFF
--- a/systems/classes/Elastic.php
+++ b/systems/classes/Elastic.php
@@ -10,7 +10,7 @@ class Elastic{
 
     if(!$config["elasticsearch"]["status"]){ return false; }
 
-		$this->$client = ClientBuilder::create()->build();
+                $this->client = ClientBuilder::create()->build();
 
 	}
 
@@ -177,7 +177,7 @@ class Elastic{
 
 	    	try{
 
-	    		return $this->$client->index($params);
+                        return $this->client->index($params);
 
 	    	} catch (Exception $e) {
 
@@ -208,7 +208,7 @@ class Elastic{
 
 	    	try{
 
-	    		return $this->$client->update($params);
+                        return $this->client->update($params);
 
 	    	} catch (Exception $e) {
 
@@ -227,7 +227,7 @@ class Elastic{
         
 	    	try{
 
-	    		return $this->$client->delete($params);
+                        return $this->client->delete($params);
 
 	    	} catch (Exception $e) {
 
@@ -246,7 +246,7 @@ class Elastic{
 
 	    	try{
 
-	    		return $this->$client->get($params);
+                        return $this->client->get($params);
 
 	    	} catch (Exception $e) {
 
@@ -265,7 +265,7 @@ class Elastic{
       
     	try{
 
-    		return $this->$client->search($params);
+                return $this->client->search($params);
 
     	} catch (Exception $e) {
 


### PR DESCRIPTION
## Summary
- correct property usage in `Elastic.php`

## Testing
- `php -l systems/classes/Elastic.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_685877065f588332bafe8aac280c366e