### PR TITLE
Extend registration flow

### DIFF
--- a/systems/ajax/profile/reg_finish.php
+++ b/systems/ajax/profile/reg_finish.php
@@ -1,11 +1,16 @@
 <?php
 
+global $Main, $config;
+
 $error = [];
 
 $user_login = clear( $_POST["user_login"] );
-$user_name = clear( $_POST["user_name"] );
 $user_code_login = (int)$_POST["user_code_login"];
 $user_pass = clear( $_POST["user_pass"] );
+$phone = formatPhone($_POST["phone"]);
+$description = clear($_POST["description"]);
+$social_links = clear($_POST["social_links"]);
+$preferences = isset($_POST['preferences']) ? $_POST['preferences'] : [];
 
 if($settings["registration_method"] == 1){
 
@@ -65,17 +70,58 @@ if( mb_strlen($user_pass, "UTF-8") < 6 || mb_strlen($user_pass, "UTF-8") > 25 ){
  $error['user_pass'] = $ULang->t("Пожалуйста, укажите пароль от 6-ти до 25 символов.");
 }
 
-if(!$user_name){
- $error['user_name'] = $ULang->t("Пожалуйста, укажите Ваше имя");
+$validatePhone = validatePhone($phone);
+if(!$validatePhone['status']){
+  $error['phone'] = $validatePhone['error'];
 }
+
+$avatar = $Main->uploadedImage(["files"=>$_FILES['avatar'], "path"=>$config['media']['avatar'], "prefix_name"=>'avatar']);
+if($avatar['error']){
+  $error['avatar'] = implode("\n", $avatar['error']);
+}
+$avatar_name = $avatar['name'];
+
+$gesture = $Main->uploadedImage(["files"=>$_FILES['gesture'], "path"=>$config['media']['user_attach'], "prefix_name"=>'gesture']);
+if($gesture['error']){
+  $error['gesture'] = implode("\n", $gesture['error']);
+}
+$gesture_name = $gesture['name'];
+
 
 if( !$error ){
 
- $result = $Profile->auth_reg(array("method"=>$settings["registration_method"],"email"=>$user_email,"phone"=>$user_phone,"name"=>$user_name, "activation" => 1, "pass" => $user_pass));
+ $result = $Profile->auth_reg(array("method"=>$settings["registration_method"],"email"=>$user_email,"phone"=>$phone,"name"=>$_SESSION['reg_data']['name'], "activation" => 0, "pass" => $user_pass, "avatar"=>$avatar_name));
 
- echo json_encode( array( "status"=>$result["status"],"answer" => $result["answer"], "reg" => 1, "location" => _link( "user/".$result["data"]["clients_id_hash"] ) ) );
+ if($result['status']){
+   update("UPDATE uni_clients SET gender=?, role=?, preferred_gender=?, age=?, city=?, description=?, verify_photo=?, verify_gesture=?, social_links=?, is_email_verified=?, is_phone_verified=?, phone=?, clients_status=0 WHERE clients_id=?", [
+     $_SESSION['reg_data']['gender'],
+     $_SESSION['reg_data']['role'],
+     $_SESSION['reg_data']['looking_for'],
+     $_SESSION['reg_data']['age'],
+     $_SESSION['reg_data']['city'],
+     $description,
+     $avatar_name,
+     $gesture_name,
+     $social_links,
+     intval($_SESSION['reg_data']['email_verified']),
+     0,
+     $phone,
+     $result['data']['clients_id']
+   ]);
 
- unset($_SESSION["verify_login"]);
+   if($preferences){
+     foreach($preferences as $pref){
+       insert("INSERT INTO user_sex_preferences(user_id,preference_id) VALUES(?,?)", [$result['data']['clients_id'], intval($pref)]);
+     }
+   }
+
+   echo json_encode( array( "status"=>true, "reg" => 1, "location" => _link( "user/".$result["data"]["clients_id_hash"] ) ) );
+
+   unset($_SESSION["verify_login"]);
+   unset($_SESSION['reg_data']);
+ }else{
+   echo json_encode(array("status"=>false, "answer" => $result['answer']));
+ }
 
 }else{
 

--- a/systems/ajax/profile/registration.php
+++ b/systems/ajax/profile/registration.php
@@ -3,6 +3,31 @@
 $error = [];
 
 $user_login = clear($_POST["user_login"]);
+$name = clear($_POST["name"]);
+$age = (int)$_POST["age"];
+$gender = clear($_POST["gender"]);
+$role = clear($_POST["role"]);
+$looking_for = clear($_POST["looking_for"]);
+$city = clear($_POST["city"]);
+
+if(!$name){
+  $error["name"] = $ULang->t("Пожалуйста, укажите Ваше имя");
+}
+if($age < 18){
+  $error["age"] = $ULang->t("Возраст должен быть не меньше 18");
+}
+if(!$gender){
+  $error["gender"] = $ULang->t("Укажите пол");
+}
+if(!$role){
+  $error["role"] = $ULang->t("Укажите роль");
+}
+if(!$looking_for){
+  $error["looking_for"] = $ULang->t("Укажите кого ищете");
+}
+if(!$city){
+  $error["city"] = $ULang->t("Укажите город");
+}
 
 if($settings["registration_method"] == 1){
 
@@ -55,6 +80,16 @@ $error["captcha"] = $ULang->t("Неверный код с картинки");
 }
 
 if(!$error){
+
+ $_SESSION['reg_data'] = [
+   'name' => $name,
+   'age' => $age,
+   'gender' => $gender,
+   'role' => $role,
+   'looking_for' => $looking_for,
+   'city' => $city,
+   'email' => $user_email
+ ];
 
  if($user_email){
     $getUser = findOne("uni_clients","clients_email = ?", array( $user_email ));

--- a/systems/ajax/profile/verify_login.php
+++ b/systems/ajax/profile/verify_login.php
@@ -28,6 +28,7 @@ if(!$_SESSION["verify_login"][$user_login]["code"] || $_SESSION["verify_login"][
 if(!$error){
 
  unset($_SESSION["auth_captcha"]);
+ $_SESSION['reg_data']['email_verified'] = true;
  echo json_encode( array( "status"=>true ) );
 
 }else{

--- a/templates/include/auth.php
+++ b/templates/include/auth.php
@@ -82,23 +82,39 @@
     <?php } ?>
 
     <div class="auth-block-right-box-tab-1-1" >
-      
-      <?php if($settings["registration_method"] == 1){ ?>
-      <div class="input-phone-format" >
-      
-        <input type="text"  class="form-control input-style2-custom phone-mask" data-format="<?php echo getFormatPhone(); ?>" placeholder="<?php echo $ULang->t("Номер телефона"); ?>" name="user_login">
-        
-        <?php echo outBoxChangeFormatPhone(); ?>
 
-      </div>
-      <?php }elseif($settings["registration_method"] == 2){ ?>
-      <input type="text"  class="form-control input-style2-custom" placeholder="<?php echo $ULang->t("Телефон или электронная почта"); ?>" name="user_login">
-      <?php }elseif($settings["registration_method"] == 3){ ?>
+      <input type="text"  class="form-control input-style2-custom" placeholder="<?php echo $ULang->t("Ваше имя"); ?>" name="name">
+      <div class="msg-error mb10" data-name="name" ></div>
+
+      <input type="number"  class="form-control input-style2-custom" placeholder="<?php echo $ULang->t("Возраст"); ?>" name="age">
+      <div class="msg-error mb10" data-name="age" ></div>
+
+      <select class="form-control input-style2-custom" name="gender">
+        <option value="male" ><?php echo $ULang->t("Мужской"); ?></option>
+        <option value="female" ><?php echo $ULang->t("Женский"); ?></option>
+        <option value="other" ><?php echo $ULang->t("Другой"); ?></option>
+      </select>
+      <div class="msg-error mb10" data-name="gender" ></div>
+
+      <select class="form-control input-style2-custom" name="role">
+        <option value="sponsor" ><?php echo $ULang->t("Спонсор"); ?></option>
+        <option value="model" ><?php echo $ULang->t("Модель"); ?></option>
+      </select>
+      <div class="msg-error mb10" data-name="role" ></div>
+
+      <select class="form-control input-style2-custom" name="looking_for">
+        <option value="male" ><?php echo $ULang->t("Ищу мужчину"); ?></option>
+        <option value="female" ><?php echo $ULang->t("Ищу женщину"); ?></option>
+        <option value="both" ><?php echo $ULang->t("Ищу всех"); ?></option>
+      </select>
+      <div class="msg-error mb10" data-name="looking_for" ></div>
+
+      <input type="text"  class="form-control input-style2-custom" placeholder="<?php echo $ULang->t("Город"); ?>" name="city">
+      <div class="msg-error mb10" data-name="city" ></div>
+
       <input type="text"  class="form-control input-style2-custom" placeholder="<?php echo $ULang->t("Электронная почта"); ?>" name="user_login">
-      <?php } ?>
-      
       <div class="msg-error mb10" data-name="user_login" ></div>
-  
+
       <div class="auth-captcha" style="display: block;" >
         <div class="row" >
           <div class="col-lg-4 col-12" ><img src="" ></div>
@@ -106,7 +122,7 @@
         </div>
         <div class="msg-error mb10" data-name="captcha" ></div>
       </div>
-  
+
       <button class="button-style-custom schema-color-button color-green action-reg-send mt20" ><?php echo $ULang->t("Продолжить"); ?></button>
 
     </div>
@@ -128,14 +144,38 @@
     </div>
 
     <div class="auth-block-right-box-tab-1-3" >
+      <form class="reg-finish-form" enctype="multipart/form-data">
 
-      <input type="text"  class="form-control input-style2-custom" placeholder="<?php echo $ULang->t("Ваше имя"); ?>" name="user_name">
-      <div class="msg-error mb10" data-name="user_name" ></div>
+        <input type="file" name="avatar" class="form-control mb10" >
+        <div class="msg-error mb10" data-name="avatar" ></div>
 
-      <input type="password"  class="form-control input-style2-custom" placeholder="<?php echo $ULang->t("Пароль"); ?>" maxlength="25" name="user_pass">
-      <div class="msg-error mb10" data-name="user_pass" ></div>
+        <textarea class="form-control mb10" name="description" placeholder="<?php echo $ULang->t("Описание"); ?>"></textarea>
+        <div class="msg-error mb10" data-name="description" ></div>
 
-      <button class="button-style-custom schema-color-button color-green action-reg-finish mt20" ><?php echo $ULang->t("Завершить регистрацию"); ?></button>           
+        <?php $preferences = getAll('select * from sex_preferences'); ?>
+        <?php if($preferences){ ?>
+          <div class="mb10 preferences-box">
+            <?php foreach($preferences as $pref){ ?>
+              <label class="checkbox mr10"><input type="checkbox" name="preferences[]" value="<?php echo $pref['id']; ?>"><span></span><?php echo $pref['name']; ?></label>
+            <?php } ?>
+          </div>
+        <?php } ?>
+
+        <input type="text"  class="form-control input-style2-custom" placeholder="<?php echo $ULang->t("Телефон"); ?>" name="phone">
+        <div class="msg-error mb10" data-name="phone" ></div>
+
+        <input type="password"  class="form-control input-style2-custom" placeholder="<?php echo $ULang->t("Пароль"); ?>" maxlength="25" name="user_pass">
+        <div class="msg-error mb10" data-name="user_pass" ></div>
+
+        <input type="text" class="form-control input-style2-custom" placeholder="<?php echo $ULang->t("Социальные сети"); ?>" name="social_links">
+        <div class="msg-error mb10" data-name="social_links" ></div>
+
+        <input type="file" name="gesture" class="form-control mb10" >
+        <div class="msg-error mb10" data-name="gesture" ></div>
+
+        <button class="button-style-custom schema-color-button color-green action-reg-finish mt20" ><?php echo $ULang->t("Завершить регистрацию"); ?></button>
+
+      </form>
     </div>
 
     <?php if($settings["authorization_social"]){ ?>

--- a/templates/js/auth.js
+++ b/templates/js/auth.js
@@ -94,7 +94,7 @@ $(document).ready(function () {
 
       showLoadProcess(this_);
 
-      $.ajax({type: "POST",url: url_path + "systems/ajax/controller.php",data: "user_login=" + $(".auth-block-tab-reg input[name=user_login]").val() + "&captcha=" + $(".auth-block-tab-reg input[name=captcha]").val() + "&action=profile/registration",dataType: "json",cache: false,success: function (data) { 
+      $.ajax({type: "POST",url: url_path + "systems/ajax/controller.php",data: "name=" + $(".auth-block-tab-reg input[name=name]").val() + "&age=" + $(".auth-block-tab-reg input[name=age]").val() + "&gender=" + $(".auth-block-tab-reg select[name=gender]").val() + "&role=" + $(".auth-block-tab-reg select[name=role]").val() + "&looking_for=" + $(".auth-block-tab-reg select[name=looking_for]").val() + "&city=" + $(".auth-block-tab-reg input[name=city]").val() + "&user_login=" + $(".auth-block-tab-reg input[name=user_login]").val() + "&captcha=" + $(".auth-block-tab-reg input[name=captcha]").val() + "&action=profile/registration",dataType: "json",cache: false,success: function (data) {
 
          if( data["status"] == true ){
              
@@ -183,7 +183,12 @@ $(document).ready(function () {
       
       showLoadProcess(this_);
 
-      $.ajax({type: "POST",url: url_path + "systems/ajax/controller.php",data: "user_login=" + $(".auth-block-tab-reg input[name=user_login]").val() + "&user_code_login=" + $(".auth-block-tab-reg input[name=user_code_login]").val() + "&user_pass=" + $(".auth-block-tab-reg input[name=user_pass]").val() + "&user_name=" + $(".auth-block-tab-reg input[name=user_name]").val() + "&action=profile/reg_finish",dataType: "json",cache: false,success: function (data) { 
+      var form = $('.reg-finish-form')[0];
+      var data_form = new FormData(form);
+      data_form.append('user_login', $(".auth-block-tab-reg input[name=user_login]").val());
+      data_form.append('user_code_login', $(".auth-block-tab-reg input[name=user_code_login]").val());
+      data_form.append('action','profile/reg_finish');
+      $.ajax({type: "POST",url: url_path + "systems/ajax/controller.php",data: data_form,dataType: "json",cache: false,contentType: false,processData: false,success: function (data) {
 
          if( data["status"] == true ){
             


### PR DESCRIPTION
## Summary
- expand registration form inputs for user details and profile setup
- collect preference choices and social links
- support image uploads and gesture verification
- record registration data and confirmation status server-side

## Testing
- `git log -1 --stat`
- `php -l systems/ajax/profile/registration.php` *(fails: `php` not installed)*

------
https://chatgpt.com/codex/tasks/task_b_6858801d79288332953e50a929b2372e