### PR TITLE
Add basic verification statuses

### DIFF
--- a/cp_684cb2e048560/include/modules/clients/clients.php
+++ b/cp_684cb2e048560/include/modules/clients/clients.php
@@ -10,12 +10,12 @@ $_GET["page"] = empty($_GET["page"]) ? 1 : intval($_GET["page"]);
 $url[] = "route=clients";
 
 if($_GET['sort'] == 1){
-    $query = "clients_status=1"; 
-    $sort_name = "Активные";  
-}elseif ($_GET['sort'] == 2){                    
-    $query = "clients_status=0";  
-    $sort_name = "Не подтвержденные";                          
-}elseif ($_GET['sort'] == 3){                    
+    $query = "is_active=1";
+    $sort_name = "Активные";
+}elseif ($_GET['sort'] == 2){
+    $query = "is_active=0";
+    $sort_name = "Не активные";
+}elseif ($_GET['sort'] == 3){
     $query = "clients_status=2";  
     $sort_name = "Заблокированные";                          
 }elseif ($_GET['sort'] == 4){                    
@@ -41,7 +41,7 @@ if($_GET["search"]){
 if($query){
    $query = " where $query";
 }else{
-   $query = " where clients_status!=3";
+   $query = " where is_active=1";
 }
 
 $LINK = "?".implode("&",$url);
@@ -51,7 +51,7 @@ $LINK = "?".implode("&",$url);
 <div class="row">
    <div class="page-header">
       <div class="d-flex align-items-center">
-         <h2 class="page-header-title">Пользователи (<?php echo (int)getOne("select count(*) as total from uni_clients where clients_status!='3'")["total"]; ?>)</h2>
+         <h2 class="page-header-title">Пользователи (<?php echo (int)getOne("select count(*) as total from uni_clients where is_active=1")["total"]; ?>)</h2>
       </div>
    </div>
 </div>
@@ -88,7 +88,7 @@ $LINK = "?".implode("&",$url);
     <div class="dropdown-menu" aria-labelledby="dropdownMenuButton">
       <a class="dropdown-item" href="?route=clients">Без сортировки</a>
       <a class="dropdown-item" href="?route=clients&sort=1">Активные</a>
-      <a class="dropdown-item" href="?route=clients&sort=2">Не подтвержденные</a>
+      <a class="dropdown-item" href="?route=clients&sort=2">Не активные</a>
       <a class="dropdown-item" href="?route=clients&sort=3">Заблокированные</a>
       <a class="dropdown-item" href="?route=clients&sort=5">Верифицированные</a>
       <a class="dropdown-item" href="?route=clients&sort=6">Не верифицированные</a>

--- a/rss.php
+++ b/rss.php
@@ -119,7 +119,7 @@ if( $content == "blog" ){
 
 }elseif( $content == "ads" ){
 
-	$query = "ads_status='1' and clients_status IN(0,1) and ads_period_publication > now()";
+        $query = "ads_status='1' and is_active=1 and ads_period_publication > now()";
 	
 	if( $sort == "news" ){
         $sort = 'ORDER By ads_id DESC';

--- a/systems/api/verify/verify_email.php
+++ b/systems/api/verify/verify_email.php
@@ -29,7 +29,12 @@ if($getVerify){
 
        }
 
-       update('update uni_clients set clients_email=? where clients_id=?', [$email,$idUser]);
+       update('update uni_clients set clients_email=?, is_email_verified=1 where clients_id=?', [$email,$idUser]);
+
+       $user = findOne('uni_clients','clients_id=?',[$idUser]);
+       if($user['is_phone_verified']){
+           update('update uni_clients set is_active=1 where clients_id=?',[$idUser]);
+       }
        update('delete from uni_verify_code where id=?', [$getVerify['id']]);
        
        echo json_encode(['status'=>true]);

--- a/systems/api/verify/verify_phone.php
+++ b/systems/api/verify/verify_phone.php
@@ -18,7 +18,13 @@ $getVerify = findOne('uni_verify_code','user_id=? and phone=?', [$idUser,$phone]
 
 if($getVerify){
     if($getVerify['code'] == $code){
-       update('update uni_clients set clients_phone=? where clients_id=?', [$phone,$idUser]);
+       update('update uni_clients set clients_phone=?, is_phone_verified=1 where clients_id=?', [$phone,$idUser]);
+
+       $user = findOne('uni_clients','clients_id=?',[$idUser]);
+       if($user['is_email_verified']){
+           update('update uni_clients set is_active=1 where clients_id=?',[$idUser]);
+       }
+
        update('delete from uni_verify_code where id=?', [$getVerify['id']]);
        echo json_encode(['status'=>true]);
     }else{

--- a/systems/classes/CategoryBoard.php
+++ b/systems/classes/CategoryBoard.php
@@ -403,13 +403,13 @@ class CategoryBoard{
           }else{
 
              if($_SESSION["geo"]["data"]["city_id"]){
-                 $count = (int)getOne("select count(ads_id) as total from uni_ads INNER JOIN `uni_clients` ON `uni_clients`.clients_id = `uni_ads`.ads_id_user where ads_status='1' and clients_status IN(0,1) and ads_period_publication > now() and ads_id_cat IN(".implode(",", $idsBuildArray).") and ads_city_id=? and ads_id_user=?", [$_SESSION["geo"]["data"]["city_id"],$user_id])["total"];
+                 $count = (int)getOne("select count(ads_id) as total from uni_ads INNER JOIN `uni_clients` ON `uni_clients`.clients_id = `uni_ads`.ads_id_user where ads_status='1' and uni_clients.is_active=1 and ads_period_publication > now() and ads_id_cat IN(".implode(",", $idsBuildArray).") and ads_city_id=? and ads_id_user=?", [$_SESSION["geo"]["data"]["city_id"],$user_id])["total"];
              }elseif($_SESSION["geo"]["data"]["region_id"]){
-                 $count = (int)getOne("select count(ads_id) as total from uni_ads INNER JOIN `uni_clients` ON `uni_clients`.clients_id = `uni_ads`.ads_id_user where ads_status='1' and clients_status IN(0,1) and ads_period_publication > now() and ads_id_cat IN(".implode(",", $idsBuildArray).") and ads_region_id=? and ads_id_user=?", [$_SESSION["geo"]["data"]["region_id"],$user_id])["total"];
+                 $count = (int)getOne("select count(ads_id) as total from uni_ads INNER JOIN `uni_clients` ON `uni_clients`.clients_id = `uni_ads`.ads_id_user where ads_status='1' and uni_clients.is_active=1 and ads_period_publication > now() and ads_id_cat IN(".implode(",", $idsBuildArray).") and ads_region_id=? and ads_id_user=?", [$_SESSION["geo"]["data"]["region_id"],$user_id])["total"];
              }elseif($_SESSION["geo"]["data"]["country_id"]){
-                 $count = (int)getOne("select count(ads_id) as total from uni_ads INNER JOIN `uni_clients` ON `uni_clients`.clients_id = `uni_ads`.ads_id_user where ads_status='1' and clients_status IN(0,1) and ads_period_publication > now() and ads_id_cat IN(".implode(",", $idsBuildArray).") and ads_country_id=? and ads_id_user=?", [$_SESSION["geo"]["data"]["country_id"],$user_id])["total"];
+                 $count = (int)getOne("select count(ads_id) as total from uni_ads INNER JOIN `uni_clients` ON `uni_clients`.clients_id = `uni_ads`.ads_id_user where ads_status='1' and uni_clients.is_active=1 and ads_period_publication > now() and ads_id_cat IN(".implode(",", $idsBuildArray).") and ads_country_id=? and ads_id_user=?", [$_SESSION["geo"]["data"]["country_id"],$user_id])["total"];
              }else{
-                 $count = (int)getOne("select count(ads_id) as total from uni_ads INNER JOIN `uni_clients` ON `uni_clients`.clients_id = `uni_ads`.ads_id_user where ads_status='1' and clients_status IN(0,1) and ads_period_publication > now() and ads_id_cat IN(".implode(",", $idsBuildArray).") and ads_id_user=?", [$user_id])["total"];
+                 $count = (int)getOne("select count(ads_id) as total from uni_ads INNER JOIN `uni_clients` ON `uni_clients`.clients_id = `uni_ads`.ads_id_user where ads_status='1' and uni_clients.is_active=1 and ads_period_publication > now() and ads_id_cat IN(".implode(",", $idsBuildArray).") and ads_id_user=?", [$user_id])["total"];
              }
 
           }

--- a/systems/classes/Elastic.php
+++ b/systems/classes/Elastic.php
@@ -122,7 +122,7 @@ class Elastic{
               "filter": [ 
                 { "term":  { "ads_status": "1" }},
                 '.$term.'
-                { "terms":  { "clients_status": [0,1] }},
+                { "term":  { "is_active": 1 }},
                 { "range": { "ads_period_publication": { "gte": "now" }}}
               ]
             }
@@ -142,7 +142,7 @@ class Elastic{
             "bool": {  
               "filter": [ 
                 { "term":  { "ads_status": "1" }},
-                { "terms":  { "clients_status": [0,1] }},
+                { "term":  { "is_active": 1 }},
                 { "range": { "ads_period_publication": { "gte": "now" }}}
               ]
             }

--- a/systems/classes/Profile.php
+++ b/systems/classes/Profile.php
@@ -10,6 +10,11 @@
 
 class Profile{
 
+    const STATUS_DRAFT = 'draft';
+    const STATUS_PENDING = 'pending';
+    const STATUS_VERIFIED = 'verified';
+    const STATUS_REJECTED = 'rejected';
+
     function oneUser($query = "", $param = []){
 
         return getOne("SELECT * FROM uni_clients LEFT JOIN `uni_city` ON `uni_city`.city_id = `uni_clients`.clients_city_id $query ",$param);

--- a/systems/classes/Profile.php
+++ b/systems/classes/Profile.php
@@ -2354,7 +2354,7 @@ class Profile{
                                 </div>
                             </div>
                         </div>                
-                        <?
+                        <?php
                     }
 
                 }

--- a/templates/include/shop_grid.php
+++ b/templates/include/shop_grid.php
@@ -1,6 +1,6 @@
 <?php
 $ratings = $Profile->outRating( $value["clients_shops_id_user"] );
-$count_ads = $Ads->getCount("ads_status='1' and clients_status IN(0,1) and ads_period_publication > now() and ads_id_user='{$value["clients_id"]}'");
+$count_ads = $Ads->getCount("ads_status='1' and is_active=1 and ads_period_publication > now() and ads_id_user='{$value["clients_id"]}'");
 $get_shop_slider = findOne('uni_clients_shops_slider','clients_shops_slider_id_shop=? order by clients_shops_slider_id asc', [$value["clients_shops_id"]]);
 ?>
 <div class="col-lg-3 col-md-4 col-sm-6 col-12" >

--- a/templates/include/shop_list.php
+++ b/templates/include/shop_list.php
@@ -1,6 +1,6 @@
 <?php
 $ratings = $Profile->outRating($value["clients_shops_id_user"]);
-$count_ads = $Ads->getCount("ads_status='1' and clients_status IN(0,1) and ads_period_publication > now() and ads_id_user='{$value["clients_id"]}'");
+$count_ads = $Ads->getCount("ads_status='1' and is_active=1 and ads_period_publication > now() and ads_id_user='{$value["clients_id"]}'");
 $count_reviews = (int)getOne("select count(*) as total from uni_clients_reviews where clients_reviews_id_user=?", [$value["clients_id"]])["total"];
 $get_shop_slider = findOne('uni_clients_shops_slider','clients_shops_slider_id_shop=? order by clients_shops_slider_id asc', [$value["clients_shops_id"]]);
 ?>

--- a/templates/index.tpl
+++ b/templates/index.tpl
@@ -69,7 +69,7 @@
 
                 }elseif($widgetName == "shop" && $settings["home_shop_status"]){
 
-                    $data["shops"] = getAll("select * from uni_clients_shops INNER JOIN `uni_clients` ON `uni_clients`.clients_id = `uni_clients_shops`.clients_shops_id_user where (clients_shops_time_validity > now() or clients_shops_time_validity IS NULL) and clients_shops_status=1 and clients_status IN(0,1) order by rand() limit ?", [$settings["index_out_count_shops"] ?: 16]);
+                    $data["shops"] = getAll("select * from uni_clients_shops INNER JOIN `uni_clients` ON `uni_clients`.clients_id = `uni_clients_shops`.clients_shops_id_user where (clients_shops_time_validity > now() or clients_shops_time_validity IS NULL) and clients_shops_status=1 and uni_clients.is_active=1 order by rand() limit ?", [$settings["index_out_count_shops"] ?: 16]);
 
                     if($data["shops"]){ ?>
                     <div class="mb25 title-and-link h3" > <strong><?php echo $ULang->t( "Магазины" ); ?></strong> <a href="<?php echo $Shop->linkShops(); ?>"><?php echo $ULang->t( "Все магазины" ); ?> <i class="las la-arrow-right"></i> </a> </div>
@@ -126,9 +126,9 @@
                     }
                     
                     if($settings["index_out_content_method"] == 0){
-                      $data["vip"] = $Ads->getAll( ["query"=>"ads_status='1' and clients_status IN(0,1) and ads_period_publication > now() and ads_vip='1' order by rand() limit 16", "param_search" => $param_search, "output" => 16 ] );
+                      $data["vip"] = $Ads->getAll( ["query"=>"ads_status='1' and is_active=1 and ads_period_publication > now() and ads_vip='1' order by rand() limit 16", "param_search" => $param_search, "output" => 16 ] );
                     }else{
-                      $data["vip"] = $Ads->getAll( ["query"=>"ads_status='1' and clients_status IN(0,1) and ads_period_publication > now() and ads_vip='1' $geo order by rand() limit 16", "param_search" => $param_search, "output" => 16 ] );
+                      $data["vip"] = $Ads->getAll( ["query"=>"ads_status='1' and is_active=1 and ads_period_publication > now() and ads_vip='1' $geo order by rand() limit 16", "param_search" => $param_search, "output" => 16 ] );
                     }
 
                     if($settings["main_type_products"] == 'physical'){
@@ -210,9 +210,9 @@
                     }
                     
                     if($settings["index_out_content_method"] == 0){
-                      $data["auction"] = $Ads->getAll( ["query"=>"ads_status='1' and clients_status IN(0,1) and ads_period_publication > now() and ads_auction='1' order by rand() limit 16", "output" => 16 ] );
+                      $data["auction"] = $Ads->getAll( ["query"=>"ads_status='1' and is_active=1 and ads_period_publication > now() and ads_auction='1' order by rand() limit 16", "output" => 16 ] );
                     }else{
-                      $data["auction"] = $Ads->getAll( ["query"=>"ads_status='1' and clients_status IN(0,1) and ads_period_publication > now() and ads_auction='1' $geo order by rand() limit 16", "output" => 16 ] );
+                      $data["auction"] = $Ads->getAll( ["query"=>"ads_status='1' and is_active=1 and ads_period_publication > now() and ads_auction='1' $geo order by rand() limit 16", "output" => 16 ] );
                     }
 
                     if($settings["main_type_products"] == 'physical'){

--- a/templates/profile_sidebar.tpl
+++ b/templates/profile_sidebar.tpl
@@ -12,13 +12,19 @@
         <div class="user-card-company-name" ><?php echo $user["clients_name_company"]; ?></div>
         <?php
     }
-    if($user["clients_verification_status"]){
+    if($user["is_verified"]){
         ?>
         <div class="user-card-verification-box">
             <span class="user-card-verification-status" ><?php echo $ULang->t("Профиль подтвержден"); ?></span>
-            <div><i class="las la-check"></i> <?php echo $ULang->t("Телефон подтверждён"); ?></div> 
-            <div><i class="las la-check"></i> <?php echo $ULang->t("Email подтверждён"); ?></div> 
-            <div><i class="las la-check"></i> <?php echo $ULang->t("Документы и фото проверены"); ?></div>                              
+            <div><i class="las la-check"></i> <?php echo $ULang->t("Телефон подтверждён"); ?></div>
+            <div><i class="las la-check"></i> <?php echo $ULang->t("Email подтверждён"); ?></div>
+            <div><i class="las la-check"></i> <?php echo $ULang->t("Документы и фото проверены"); ?></div>
+        </div>
+        <?php
+    }elseif($user["is_active"]){
+        ?>
+        <div class="user-card-verification-box">
+            <span class="user-card-verification-status" ><?php echo $ULang->t("На модерации"); ?></span>
         </div>
         <?php
     }else{

--- a/templates/shops.tpl
+++ b/templates/shops.tpl
@@ -71,7 +71,7 @@
                       if( $getCategoryBoard["category_board_id_parent"][0] ){
                           foreach ($getCategoryBoard["category_board_id_parent"][0] as $value) {
 
-                              $countShop = (int)getOne( 'select count(*) as total from uni_clients_shops INNER JOIN `uni_clients` ON `uni_clients`.clients_id = `uni_clients_shops`.clients_shops_id_user where (clients_shops_time_validity > now() or clients_shops_time_validity IS NULL) and clients_shops_status=1 and clients_status IN(0,1) and (clients_shops_id_theme_category=? or clients_shops_id_theme_category=?)', [ $value["category_board_id"], 0 ] )['total'];
+                              $countShop = (int)getOne( 'select count(*) as total from uni_clients_shops INNER JOIN `uni_clients` ON `uni_clients`.clients_id = `uni_clients_shops`.clients_shops_id_user where (clients_shops_time_validity > now() or clients_shops_time_validity IS NULL) and clients_shops_status=1 and uni_clients.is_active=1 and (clients_shops_id_theme_category=? or clients_shops_id_theme_category=?)', [ $value["category_board_id"], 0 ] )['total'];
                               ?>
                               <li>
                                 <a <?php if( $value["category_board_id"] == $data["current_category"]["category_board_id"] ){ echo 'class="active"'; } ?> href="<?php echo $Shop->linkShopsCategory($value["category_board_chain"]); ?>"><?php echo $ULang->t( $value["category_board_name"], [ "table" => "uni_category_board", "field" => "category_board_name" ] ); ?><span class="shop-category-list-count" ><?php echo $countShop; ?></span></a>
@@ -116,7 +116,7 @@
                       if( $getCategoryBoard["category_board_id_parent"][0] ){
                           foreach ($getCategoryBoard["category_board_id_parent"][0] as $value) {
 
-                              $countShop = (int)getOne( 'select count(*) as total from uni_clients_shops INNER JOIN `uni_clients` ON `uni_clients`.clients_id = `uni_clients_shops`.clients_shops_id_user where (clients_shops_time_validity > now() or clients_shops_time_validity IS NULL) and clients_shops_status=1 and clients_status IN(0,1) and (clients_shops_id_theme_category=? or clients_shops_id_theme_category=?)', [ $value["category_board_id"], 0 ] )['total'];
+                              $countShop = (int)getOne( 'select count(*) as total from uni_clients_shops INNER JOIN `uni_clients` ON `uni_clients`.clients_id = `uni_clients_shops`.clients_shops_id_user where (clients_shops_time_validity > now() or clients_shops_time_validity IS NULL) and clients_shops_status=1 and uni_clients.is_active=1 and (clients_shops_id_theme_category=? or clients_shops_id_theme_category=?)', [ $value["category_board_id"], 0 ] )['total'];
                               ?>
                               <li>
                                 <a <?php if($value["category_board_id"] == $data["current_category"]["category_board_id"]){ echo 'class="active"'; } ?> href="<?php echo $Shop->linkShopsCategory($value["category_board_chain"]); ?>"><?php echo $ULang->t($value["category_board_name"], [ "table" => "uni_category_board", "field" => "category_board_name" ]); ?><span class="shop-category-list-count" ><?php echo $countShop; ?></span></a>


### PR DESCRIPTION
## Summary
- add verification status constants
- mark email/phone as verified and activate profile once both confirmed
- filter active users in search queries and RSS
- show profile moderation badge
- adjust admin user filters

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_b_68588527fd5c833287907577484ccceb