### PR TITLE
Add preference and gesture management

### DIFF
--- a/config.php
+++ b/config.php
@@ -59,6 +59,7 @@ return [
       "big_image_ads" => "media/images_boards/big",
       "small_image_ads" => "media/images_boards/small",
       "manager" => "media/manager",
+      "gestures" => "media/gestures",
    ],
 
    "css_styles" => [

--- a/cp_684cb2e048560/include/modules/gestures/handlers/add.php
+++ b/cp_684cb2e048560/include/modules/gestures/handlers/add.php
@@ -1,0 +1,33 @@
+<?php
+
+define('unisitecms', true);
+session_start();
+
+$config = require "../../../../../config.php";
+require_once( $config["basePath"] . "/systems/unisite.php" );
+require_once( $config["basePath"] . "/" . $config["folder_admin"] . "/lang/" . $settings["lang_admin_default"] . ".php" );
+
+if( !(new Admin())->accessAdmin($_SESSION['cp_control_settings']) ){
+   $_SESSION["CheckMessage"]["warning"] = "Ограничение прав доступа!";
+   exit;
+}
+
+if(isAjax() == true){
+
+ $Main = new Main();
+ $error = [];
+
+ if(count($error) == 0){
+    $image = $Main->uploadedImage(["files"=>$_FILES['image'],"path"=>$config['media']['gestures'],"prefix_name"=>'gesture']);
+    if($image['error']){ $error = array_merge($error,$image['error']); }
+ }
+
+ if(count($error) == 0){
+    insert("INSERT INTO uni_gestures(image,description)VALUES(?,?)", [$image['name'],clear($_POST['description'])]);
+    $_SESSION["CheckMessage"]["success"] = "Действие успешно выполнено!";
+    echo true;
+ }else{
+    $_SESSION["CheckMessage"]["warning"] = implode("<br/>", $error);
+ }
+}
+?>

--- a/cp_684cb2e048560/include/modules/gestures/handlers/delete.php
+++ b/cp_684cb2e048560/include/modules/gestures/handlers/delete.php
@@ -1,0 +1,25 @@
+<?php
+
+define('unisitecms', true);
+session_start();
+
+$config = require "../../../../../config.php";
+require_once( $config["basePath"] . "/systems/unisite.php" );
+require_once( $config["basePath"] . "/" . $config["folder_admin"] . "/lang/" . $settings["lang_admin_default"] . ".php" );
+
+if( !(new Admin())->accessAdmin($_SESSION['cp_control_settings']) ){
+   $_SESSION["CheckMessage"]["warning"] = "Ограничение прав доступа!";
+   exit;
+}
+
+if(isAjax() == true){
+ $id = (int)$_POST['id'];
+ $item = findOne("uni_gestures","id=?",[$id]);
+ if($item){
+    if($item['image']){ @unlink($config['basePath'].'/'.$config['media']['gestures'].'/'.$item['image']); }
+    delete("delete from uni_gestures where id=?", [$id]);
+ }
+ $_SESSION["CheckMessage"]["success"] = "Действие успешно выполнено!";
+ echo true;
+}
+?>

--- a/cp_684cb2e048560/include/modules/gestures/handlers/edit.php
+++ b/cp_684cb2e048560/include/modules/gestures/handlers/edit.php
@@ -1,0 +1,39 @@
+<?php
+
+define('unisitecms', true);
+session_start();
+
+$config = require "../../../../../config.php";
+require_once( $config["basePath"] . "/systems/unisite.php" );
+require_once( $config["basePath"] . "/" . $config["folder_admin"] . "/lang/" . $settings["lang_admin_default"] . ".php" );
+
+if( !(new Admin())->accessAdmin($_SESSION['cp_control_settings']) ){
+   $_SESSION["CheckMessage"]["warning"] = "Ограничение прав доступа!";
+   exit;
+}
+
+if(isAjax() == true){
+
+ $Main = new Main();
+ $error = [];
+ $id = (int)$_POST['id'];
+ $item = findOne("uni_gestures","id=?",[$id]);
+
+ if(!$item){ exit; }
+
+ if($_FILES['image']['name']){
+    $image = $Main->uploadedImage(["files"=>$_FILES['image'],"path"=>$config['media']['gestures'],"prefix_name"=>'gesture']);
+    if($image['error']){ $error = array_merge($error,$image['error']); }
+ }else{
+    $image['name'] = $item['image'];
+ }
+
+ if(count($error) == 0){
+    update("UPDATE uni_gestures SET image=?,description=? WHERE id=?", [$image['name'],clear($_POST['description']),$id]);
+    $_SESSION["CheckMessage"]["success"] = "Данные сохранены";
+    echo true;
+ }else{
+    $_SESSION["CheckMessage"]["warning"] = implode("<br/>", $error);
+ }
+}
+?>

--- a/cp_684cb2e048560/include/modules/gestures/handlers/load_edit.php
+++ b/cp_684cb2e048560/include/modules/gestures/handlers/load_edit.php
@@ -1,0 +1,32 @@
+<?php
+
+define('unisitecms', true);
+session_start();
+
+$config = require "../../../../../config.php";
+require_once( $config["basePath"] . "/systems/unisite.php" );
+require_once( $config["basePath"] . "/" . $config["folder_admin"] . "/lang/" . $settings["lang_admin_default"] . ".php" );
+
+if( !(new Admin())->accessAdmin($_SESSION['cp_control_settings']) ){
+   exit;
+}
+
+$id = (int)$_POST['id'];
+$item = findOne("uni_gestures","id=?",[$id]);
+if($item){
+?>
+<input type="hidden" name="id" value="<?php echo $item['id']; ?>">
+<div class="form-group">
+    <label>Текущее изображение</label><br>
+    <img src="<?php echo $config['urlPath'].'/'.$config['media']['gestures'].'/'.$item['image']; ?>" height="60">
+</div>
+<div class="form-group">
+    <label>Новое изображение</label>
+    <input type="file" name="image" class="form-control">
+</div>
+<div class="form-group">
+    <label>Описание</label>
+    <input type="text" class="form-control" name="description" value="<?php echo $item['description']; ?>">
+</div>
+<?php }
+?>

--- a/cp_684cb2e048560/include/modules/gestures/index.php
+++ b/cp_684cb2e048560/include/modules/gestures/index.php
@@ -1,0 +1,115 @@
+<?php
+if( !defined('unisitecms') ) exit;
+
+$LINK = '?route=gestures';
+?>
+
+<div class="row">
+   <div class="page-header">
+      <div class="d-flex align-items-center">
+         <h2 class="page-header-title">Жесты для верификации</h2>
+      </div>
+   </div>
+</div>
+
+<div class="form-group">
+ <a href="#modal-gesture-add" data-toggle="modal" class="btn btn-gradient-04 mr-1 mb-2">Добавить</a>
+</div>
+
+<div class="row" >
+   <div class="col-lg-12" >
+      <div class="widget has-shadow">
+         <div class="widget-body">
+            <div class="table-responsive">
+                 <?php
+                    $items = getAll("SELECT * FROM uni_gestures ORDER BY id DESC");
+                    if(count($items) > 0){
+                 ?>
+                     <table class="table mb-0">
+                        <thead>
+                           <tr>
+                            <th>Изображение</th>
+                            <th>Описание</th>
+                            <th style="text-align: right;"></th>
+                           </tr>
+                        </thead>
+                        <tbody>
+                     <?php
+                        foreach($items AS $item){
+                     ?>
+                         <tr>
+                             <td><img src="<?php echo $config['urlPath'].'/'.$config['media']['gestures'].'/'.$item['image']; ?>" height="60"></td>
+                             <td><?php echo $item['description']; ?></td>
+                             <td class="td-actions" style="text-align: right;" >
+                              <a class="load-edit-gesture" data-id="<?php echo $item['id']; ?>" ><i class="la la-edit edit"></i></a>
+                              <a href="#" class="delete-gesture" data-id="<?php echo $item['id']; ?>" ><i class="la la-close delete"></i></a>
+                             </td>
+                         </tr>
+                     <?php }
+                     ?>
+                           </tbody>
+                        </table>
+                 <?php }else{ ?>
+                        <div class="plug" >
+                           <i class="la la-exclamation-triangle"></i>
+                           <p>Записей нет</p>
+                        </div>
+                 <?php } ?>
+            </div>
+         </div>
+      </div>
+   </div>
+</div>
+
+<div id="modal-gesture-add" class="modal fade">
+   <div class="modal-dialog" style="max-width: 650px;" >
+      <div class="modal-content">
+         <div class="modal-header">
+            <h4 class="modal-title">Добавить жест</h4>
+            <button type="button" class="close" data-dismiss="modal">
+            <span aria-hidden="true">×</span>
+            <span class="sr-only">close</span>
+            </button>
+         </div>
+         <div class="modal-body">
+            <form class="form-data-gesture-add" enctype="multipart/form-data">
+                <div class="form-group">
+                    <label>Изображение</label>
+                    <input type="file" name="image" class="form-control" >
+                </div>
+                <div class="form-group">
+                    <label>Описание</label>
+                    <input type="text" class="form-control" name="description" >
+                </div>
+            </form>
+         </div>
+         <div class="modal-footer">
+            <button type="button" class="btn btn-shadow" data-dismiss="modal">Закрыть</button>
+            <button type="button" class="btn btn-primary action-gesture-add">Добавить</button>
+         </div>
+      </div>
+   </div>
+</div>
+
+<div id="modal-gesture-edit" class="modal fade">
+   <div class="modal-dialog" style="max-width: 650px;" >
+      <div class="modal-content">
+         <div class="modal-header">
+            <h4 class="modal-title">Редактирование</h4>
+            <button type="button" class="close" data-dismiss="modal">
+            <span aria-hidden="true">×</span>
+            <span class="sr-only">close</span>
+            </button>
+         </div>
+         <div class="modal-body">
+            <form class="form-data-gesture-edit" enctype="multipart/form-data"></form>
+         </div>
+         <div class="modal-footer">
+            <button type="button" class="btn btn-shadow" data-dismiss="modal">Закрыть</button>
+            <button type="button" class="btn btn-primary action-gesture-edit">Сохранить</button>
+         </div>
+      </div>
+   </div>
+</div>
+
+<script type="text/javascript" src="include/modules/gestures/script.js"></script>

--- a/cp_684cb2e048560/include/modules/gestures/script.js
+++ b/cp_684cb2e048560/include/modules/gestures/script.js
@@ -1,0 +1,30 @@
+$(document).ready(function(){
+    $.getScript('files/js/javascript.js');
+
+    $(document).on('click','.action-gesture-add', function(e){
+        var form = $('.form-data-gesture-add')[0];
+        var data = new FormData(form);
+        $('.proccess_load').show();
+        $.ajax({type:'POST',url:'include/modules/gestures/handlers/add.php',data:data,contentType:false,processData:false,dataType:'html',cache:false,success:function(data){if(data==true){location.reload();}else{$('.proccess_load').hide();notification();}}});
+        e.preventDefault();
+    });
+
+    $(document).on('click','.load-edit-gesture', function(e){
+        $.ajax({type:'POST',url:'include/modules/gestures/handlers/load_edit.php',data:'id='+$(this).data('id'),dataType:'html',cache:false,success:function(data){$('.form-data-gesture-edit').html(data);$('#modal-gesture-edit').modal('show');}});
+        e.preventDefault();
+    });
+
+    $(document).on('click','.action-gesture-edit', function(e){
+        var form = $('.form-data-gesture-edit')[0];
+        var data = new FormData(form);
+        $('.proccess_load').show();
+        $.ajax({type:'POST',url:'include/modules/gestures/handlers/edit.php',data:data,contentType:false,processData:false,dataType:'html',cache:false,success:function(data){$('.proccess_load').hide();notification();}});
+        e.preventDefault();
+    });
+
+    $(document).on('click','.delete-gesture', function(){
+        var id = $(this).data('id');
+        swal({title:'Вы действительно хотите выполнить удаление?',type:'warning',showCancelButton:true,confirmButtonColor:'#3085d6',cancelButtonColor:'#d33',confirmButtonText:'Да',cancelButtonText:'Нет'}).then((result)=>{if(result.value){$('.proccess_load').show();$.ajax({type:'POST',url:'include/modules/gestures/handlers/delete.php',data:'id='+id,dataType:'html',cache:false,success:function(data){if(data==true){location.reload();}else{$('.proccess_load').hide();notification();}}});}});
+        return false;
+    });
+});

--- a/cp_684cb2e048560/include/modules/sex_preferences/handlers/add.php
+++ b/cp_684cb2e048560/include/modules/sex_preferences/handlers/add.php
@@ -1,0 +1,30 @@
+<?php
+
+define('unisitecms', true);
+session_start();
+
+$config = require "../../../../../config.php";
+require_once( $config["basePath"] . "/systems/unisite.php" );
+require_once( $config["basePath"] . "/" . $config["folder_admin"] . "/lang/" . $settings["lang_admin_default"] . ".php" );
+
+if( !(new Admin())->accessAdmin($_SESSION['cp_control_settings']) ){
+   $_SESSION["CheckMessage"]["warning"] = "Ограничение прав доступа!";
+   exit;
+}
+
+if(isAjax() == true){
+
+ $name = clear($_POST['name']);
+ $error = [];
+
+ if(!$name){ $error[] = 'Укажите название'; }
+
+ if(count($error) == 0){
+    insert("INSERT INTO sex_preferences(name)VALUES(?)", [$name]);
+    $_SESSION["CheckMessage"]["success"] = "Действие успешно выполнено!";
+    echo true;
+ }else{
+    $_SESSION["CheckMessage"]["warning"] = implode("<br/>", $error);
+ }
+}
+?>

--- a/cp_684cb2e048560/include/modules/sex_preferences/handlers/delete.php
+++ b/cp_684cb2e048560/include/modules/sex_preferences/handlers/delete.php
@@ -1,0 +1,22 @@
+<?php
+
+define('unisitecms', true);
+session_start();
+
+$config = require "../../../../../config.php";
+require_once( $config["basePath"] . "/systems/unisite.php" );
+require_once( $config["basePath"] . "/" . $config["folder_admin"] . "/lang/" . $settings["lang_admin_default"] . ".php" );
+
+if( !(new Admin())->accessAdmin($_SESSION['cp_control_settings']) ){
+   $_SESSION["CheckMessage"]["warning"] = "Ограничение прав доступа!";
+   exit;
+}
+
+if(isAjax() == true){
+
+ $id = (int)$_POST['id'];
+ delete("delete from sex_preferences where id=?", [$id]);
+ $_SESSION["CheckMessage"]["success"] = "Действие успешно выполнено!";
+ echo true;
+}
+?>

--- a/cp_684cb2e048560/include/modules/sex_preferences/handlers/edit.php
+++ b/cp_684cb2e048560/include/modules/sex_preferences/handlers/edit.php
@@ -1,0 +1,31 @@
+<?php
+
+define('unisitecms', true);
+session_start();
+
+$config = require "../../../../../config.php";
+require_once( $config["basePath"] . "/systems/unisite.php" );
+require_once( $config["basePath"] . "/" . $config["folder_admin"] . "/lang/" . $settings["lang_admin_default"] . ".php" );
+
+if( !(new Admin())->accessAdmin($_SESSION['cp_control_settings']) ){
+   $_SESSION["CheckMessage"]["warning"] = "Ограничение прав доступа!";
+   exit;
+}
+
+if(isAjax() == true){
+
+ $id = (int)$_POST['id'];
+ $name = clear($_POST['name']);
+ $error = [];
+
+ if(!$name){ $error[] = 'Укажите название'; }
+
+ if(count($error) == 0){
+    update("UPDATE sex_preferences SET name=? WHERE id=?", [$name,$id]);
+    $_SESSION["CheckMessage"]["success"] = "Данные сохранены";
+    echo true;
+ }else{
+    $_SESSION["CheckMessage"]["warning"] = implode("<br/>", $error);
+ }
+}
+?>

--- a/cp_684cb2e048560/include/modules/sex_preferences/handlers/load_edit.php
+++ b/cp_684cb2e048560/include/modules/sex_preferences/handlers/load_edit.php
@@ -1,0 +1,25 @@
+<?php
+
+define('unisitecms', true);
+session_start();
+
+$config = require "../../../../../config.php";
+require_once( $config["basePath"] . "/systems/unisite.php" );
+require_once( $config["basePath"] . "/" . $config["folder_admin"] . "/lang/" . $settings["lang_admin_default"] . ".php" );
+
+if( !(new Admin())->accessAdmin($_SESSION['cp_control_settings']) ){
+   exit;
+}
+
+$id = (int)$_POST['id'];
+$item = findOne("sex_preferences","id=?",[$id]);
+if($item){
+?>
+   <input type="hidden" name="id" value="<?php echo $item['id']; ?>" >
+   <div class="form-group">
+       <label>Название</label>
+       <input type="text" class="form-control" name="name" value="<?php echo $item['name']; ?>" >
+   </div>
+<?php
+}
+?>

--- a/cp_684cb2e048560/include/modules/sex_preferences/index.php
+++ b/cp_684cb2e048560/include/modules/sex_preferences/index.php
@@ -1,0 +1,114 @@
+<?php
+if( !defined('unisitecms') ) exit;
+
+$LINK = '?route=sex_preferences';
+?>
+
+<div class="row">
+   <div class="page-header">
+      <div class="d-flex align-items-center">
+         <h2 class="page-header-title">Сексуальные предпочтения</h2>
+      </div>
+   </div>
+</div>
+
+<div class="form-group">
+ <a href="#modal-preference-add" data-toggle="modal" class="btn btn-gradient-04 mr-1 mb-2">Добавить</a>
+</div>
+
+<div class="row" >
+   <div class="col-lg-12" >
+      <div class="widget has-shadow">
+         <div class="widget-body">
+            <div class="table-responsive">
+                 <?php
+                    $items = getAll("SELECT * FROM sex_preferences ORDER BY name ASC");
+                    if(count($items) > 0){
+                 ?>
+                     <table class="table mb-0">
+                        <thead>
+                           <tr>
+                            <th>Название</th>
+                            <th style="text-align: right;"></th>
+                           </tr>
+                        </thead>
+                        <tbody>
+                     <?php
+                        foreach($items AS $item){
+                     ?>
+                         <tr>
+                             <td><?php echo $item["name"]; ?></td>
+                             <td class="td-actions" style="text-align: right;" >
+                              <a class="load-edit-preference" data-id="<?php echo $item['id']; ?>" ><i class="la la-edit edit"></i></a>
+                              <a href="#" class="delete-preference" data-id="<?php echo $item['id']; ?>" ><i class="la la-close delete"></i></a>
+                             </td>
+                         </tr>
+                     <?php
+                        }
+                     ?>
+                           </tbody>
+                        </table>
+                 <?php
+                    }else{
+                 ?>
+                        <div class="plug" >
+                           <i class="la la-exclamation-triangle"></i>
+                           <p>Записей нет</p>
+                        </div>
+                 <?php
+                    }
+                 ?>
+            </div>
+         </div>
+      </div>
+   </div>
+</div>
+
+<div id="modal-preference-add" class="modal fade">
+   <div class="modal-dialog" style="max-width: 650px;" >
+      <div class="modal-content">
+         <div class="modal-header">
+            <h4 class="modal-title">Добавить предпочтение</h4>
+            <button type="button" class="close" data-dismiss="modal">
+            <span aria-hidden="true">×</span>
+            <span class="sr-only">close</span>
+            </button>
+         </div>
+         <div class="modal-body">
+            <form class="form-data-preference-add" >
+                <div class="form-group">
+                    <label>Название</label>
+                    <input type="text" class="form-control" name="name" >
+                </div>
+            </form>
+         </div>
+         <div class="modal-footer">
+            <button type="button" class="btn btn-shadow" data-dismiss="modal">Закрыть</button>
+            <button type="button" class="btn btn-primary action-preference-add">Добавить</button>
+         </div>
+      </div>
+   </div>
+</div>
+
+<div id="modal-preference-edit" class="modal fade">
+   <div class="modal-dialog" style="max-width: 650px;" >
+      <div class="modal-content">
+         <div class="modal-header">
+            <h4 class="modal-title">Редактирование</h4>
+            <button type="button" class="close" data-dismiss="modal">
+            <span aria-hidden="true">×</span>
+            <span class="sr-only">close</span>
+            </button>
+         </div>
+         <div class="modal-body">
+            <form class="form-data-preference-edit"></form>
+         </div>
+         <div class="modal-footer">
+            <button type="button" class="btn btn-shadow" data-dismiss="modal">Закрыть</button>
+            <button type="button" class="btn btn-primary action-preference-edit">Сохранить</button>
+         </div>
+      </div>
+   </div>
+</div>
+
+<script type="text/javascript" src="include/modules/sex_preferences/script.js"></script>

--- a/cp_684cb2e048560/include/modules/sex_preferences/script.js
+++ b/cp_684cb2e048560/include/modules/sex_preferences/script.js
@@ -1,0 +1,26 @@
+$(document).ready(function(){
+    $.getScript('files/js/javascript.js');
+
+    $(document).on('click','.action-preference-add', function(e){
+        $('.proccess_load').show();
+        $.ajax({type:'POST',url:'include/modules/sex_preferences/handlers/add.php',data:$('.form-data-preference-add').serialize(),dataType:'html',cache:false,success:function(data){if(data==true){location.reload();}else{$('.proccess_load').hide();notification();}}});
+        e.preventDefault();
+    });
+
+    $(document).on('click','.load-edit-preference', function(e){
+        $.ajax({type:'POST',url:'include/modules/sex_preferences/handlers/load_edit.php',data:'id='+$(this).attr('data-id'),dataType:'html',cache:false,success:function(data){$('.form-data-preference-edit').html(data);$('#modal-preference-edit').modal('show');}});
+        e.preventDefault();
+    });
+
+    $(document).on('click','.action-preference-edit', function(e){
+        $('.proccess_load').show();
+        $.ajax({type:'POST',url:'include/modules/sex_preferences/handlers/edit.php',data:$('.form-data-preference-edit').serialize(),dataType:'html',cache:false,success:function(data){$('.proccess_load').hide();notification();}});
+        e.preventDefault();
+    });
+
+    $(document).on('click','.delete-preference', function(){
+        var id = $(this).data('id');
+        swal({title:'Вы действительно хотите выполнить удаление?',type:'warning',showCancelButton:true,confirmButtonColor:'#3085d6',cancelButtonColor:'#d33',confirmButtonText:'Да',cancelButtonText:'Нет'}).then((result)=>{if(result.value){$('.proccess_load').show();$.ajax({type:'POST',url:'include/modules/sex_preferences/handlers/delete.php',data:'id='+id,dataType:'html',cache:false,success:function(data){if(data==true){location.reload();}else{$('.proccess_load').hide();notification();}}});}});
+        return false;
+    });
+});

--- a/cp_684cb2e048560/index.php
+++ b/cp_684cb2e048560/index.php
@@ -120,6 +120,10 @@ if($_GET["route"] == "users" || $_GET["route"] == "user" || $_GET["route"] == "a
   if(!$_SESSION["cp_control_board"]){
     header("Location: ?route=index");
   }
+}elseif($_GET["route"] == "sex_preferences" || $_GET["route"] == "gestures"){
+  if(!$_SESSION["cp_control_settings"]){
+    header("Location: ?route=index");
+  }
 }
 
 

--- a/systems/ajax/profile/reg_finish.php
+++ b/systems/ajax/profile/reg_finish.php
@@ -6,6 +6,8 @@ $user_login = clear( $_POST["user_login"] );
 $user_name = clear( $_POST["user_name"] );
 $user_code_login = (int)$_POST["user_code_login"];
 $user_pass = clear( $_POST["user_pass"] );
+$user_preferences = clear($_POST["preferences"]);
+$verify_gesture = (int)$_POST["verify_gesture"];
 
 if($settings["registration_method"] == 1){
 
@@ -71,7 +73,16 @@ if(!$user_name){
 
 if( !$error ){
 
- $result = $Profile->auth_reg(array("method"=>$settings["registration_method"],"email"=>$user_email,"phone"=>$user_phone,"name"=>$user_name, "activation" => 1, "pass" => $user_pass));
+ $result = $Profile->auth_reg(array(
+    "method"=>$settings["registration_method"],
+    "email"=>$user_email,
+    "phone"=>$user_phone,
+    "name"=>$user_name,
+    "activation" => 1,
+    "pass" => $user_pass,
+    "preferences" => $user_preferences,
+    "verify_gesture" => $verify_gesture
+  ));
 
  echo json_encode( array( "status"=>$result["status"],"answer" => $result["answer"], "reg" => 1, "location" => _link( "user/".$result["data"]["clients_id_hash"] ) ) );
 

--- a/systems/classes/Profile.php
+++ b/systems/classes/Profile.php
@@ -821,7 +821,17 @@ class Profile{
      
      $clients_id_hash = md5($array["email"] ? $array["email"] : $array["phone"]);
 
-     $insert_id = insert("INSERT INTO uni_clients(clients_pass,clients_email,clients_phone,clients_name,clients_surname,clients_ip,clients_id_hash,clients_status,clients_datetime_add,clients_notifications,clients_social_identity,clients_avatar,clients_ref_id,clients_verification_code)VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?)", array($password_hash,$array["email"],$array["phone"],$array["name"],$array["surname"],clear($_SERVER["REMOTE_ADDR"]),$clients_id_hash,intval($array["activation"]), date("Y-m-d H:i:s"), $notifications,$array["social_link"],$array["avatar"],genRefId(),genVerificationCode())); 
+    $insert_id = insert("INSERT INTO uni_clients(clients_pass,clients_email,clients_phone,clients_name,clients_surname,clients_ip,clients_id_hash,clients_status,clients_datetime_add,clients_notifications,clients_social_identity,clients_avatar,clients_ref_id,clients_verification_code)VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?)", array($password_hash,$array["email"],$array["phone"],$array["name"],$array["surname"],clear($_SERVER["REMOTE_ADDR"]),$clients_id_hash,intval($array["activation"]), date("Y-m-d H:i:s"), $notifications,$array["social_link"],$array["avatar"],genRefId(),genVerificationCode()));
+
+    if($array['verify_gesture']){
+        update("UPDATE uni_clients SET verify_gesture=? WHERE clients_id=?", [$array['verify_gesture'],$insert_id]);
+    }
+    if($array['preferences']){
+        $prefs = explode(',', $array['preferences']);
+        foreach($prefs as $pref){
+            if($pref) smart_insert('user_sex_preferences',[ 'user_id'=>$insert_id,'preference_id'=>(int)$pref ]);
+        }
+    }
 
      $_SESSION['profile']['id'] = $insert_id;
 
@@ -2349,7 +2359,7 @@ class Profile{
                                 </div>
                             </div>
                         </div>                
-                        <?
+                        <?php
                     }
 
                 }

--- a/templates/include/auth.php
+++ b/templates/include/auth.php
@@ -132,10 +132,29 @@
       <input type="text"  class="form-control input-style2-custom" placeholder="<?php echo $ULang->t("Ваше имя"); ?>" name="user_name">
       <div class="msg-error mb10" data-name="user_name" ></div>
 
+      <?php $prefs = getAll("SELECT * FROM sex_preferences"); ?>
+      <?php if($prefs){ ?>
+      <select name="user_preferences[]" class="selectpicker" multiple>
+        <?php foreach($prefs as $p){ ?>
+           <option value="<?php echo $p['id']; ?>" ><?php echo $p['name']; ?></option>
+        <?php } ?>
+      </select>
+      <div class="msg-error mb10" data-name="user_preferences" ></div>
+      <?php } ?>
+
+      <?php $gesture = getOne("SELECT * FROM uni_gestures ORDER BY RAND() LIMIT 1"); ?>
+      <?php if($gesture){ ?>
+      <div class="verify-gesture text-center mt10">
+         <p><?php echo $gesture['description']; ?></p>
+         <img src="<?php echo $config['urlPath'].'/'.$config['media']['gestures'].'/'.$gesture['image']; ?>" height="80" >
+         <input type="hidden" name="verify_gesture" value="<?php echo $gesture['id']; ?>">
+      </div>
+      <?php } ?>
+
       <input type="password"  class="form-control input-style2-custom" placeholder="<?php echo $ULang->t("Пароль"); ?>" maxlength="25" name="user_pass">
       <div class="msg-error mb10" data-name="user_pass" ></div>
 
-      <button class="button-style-custom schema-color-button color-green action-reg-finish mt20" ><?php echo $ULang->t("Завершить регистрацию"); ?></button>           
+      <button class="button-style-custom schema-color-button color-green action-reg-finish mt20" ><?php echo $ULang->t("Завершить регистрацию"); ?></button>
     </div>
 
     <?php if($settings["authorization_social"]){ ?>

--- a/templates/js/auth.js
+++ b/templates/js/auth.js
@@ -183,7 +183,9 @@ $(document).ready(function () {
       
       showLoadProcess(this_);
 
-      $.ajax({type: "POST",url: url_path + "systems/ajax/controller.php",data: "user_login=" + $(".auth-block-tab-reg input[name=user_login]").val() + "&user_code_login=" + $(".auth-block-tab-reg input[name=user_code_login]").val() + "&user_pass=" + $(".auth-block-tab-reg input[name=user_pass]").val() + "&user_name=" + $(".auth-block-tab-reg input[name=user_name]").val() + "&action=profile/reg_finish",dataType: "json",cache: false,success: function (data) { 
+      var prefs = $(".auth-block-tab-reg select[name='user_preferences[]']").val();
+      if(prefs){ prefs = prefs.join(','); }else{ prefs = ''; }
+      $.ajax({type: "POST",url: url_path + "systems/ajax/controller.php",data: "user_login=" + $(".auth-block-tab-reg input[name=user_login]").val() + "&user_code_login=" + $(".auth-block-tab-reg input[name=user_code_login]").val() + "&user_pass=" + $(".auth-block-tab-reg input[name=user_pass]").val() + "&user_name=" + $(".auth-block-tab-reg input[name=user_name]").val() + "&preferences=" + prefs + "&verify_gesture=" + $(".auth-block-tab-reg input[name=verify_gesture]").val() + "&action=profile/reg_finish",dataType: "json",cache: false,success: function (data) {
 
          if( data["status"] == true ){
             


### PR DESCRIPTION
## Summary
- manage sex preferences and gestures dictionaries
- store gestures in new media path
- integrate preferences and gestures in registration
- fix short PHP tag in Profile class

## Testing
- `php -l cp_684cb2e048560/include/modules/gestures/handlers/add.php`
- `php -l systems/classes/Profile.php`


------
https://chatgpt.com/codex/tasks/task_b_68588842d3448332975926548371e9e9