### PR TITLE
Add profile verification fields

### DIFF
--- a/cp_684cb2e048560/include/modules/clients/view.php
+++ b/cp_684cb2e048560/include/modules/clients/view.php
@@ -207,11 +207,18 @@ $data["requisites_company"] = $getUser['clients_requisites_company'] ? json_deco
                            <div class="dropdown-menu" aria-labelledby="dropdownMenuButton">
                            <a class="dropdown-item view-change-status-verification-user" data-id="<?php echo $getUser["clients_id"]; ?>" data-status="1" href="#">Подтвержден</a>
                            <a class="dropdown-item view-change-status-verification-user" data-id="<?php echo $getUser["clients_id"]; ?>" data-status="0" href="#">Не подтвержден</a>
-                           </div>
+                          </div>
 
-                        </div>                         
-                      </div>
-                   </div>
+                       </div>
+                     </div>
+                  </div>
+                  <div class="form-group row d-flex align-items-center mb-5" >
+                     <label class="col-lg-2 form-control-label d-flex justify-content-lg-end">Подтверждения</label>
+                     <div class="col-lg-6">
+                        <?php if($getUser["is_email_verified"]){ ?><span class="badge badge-success mr5">Email</span><?php } ?>
+                        <?php if($getUser["is_phone_verified"]){ ?><span class="badge badge-success mr5">Телефон</span><?php } ?>
+                     </div>
+                  </div>
 
                   <?php
                   

--- a/cp_684cb2e048560/include/modules/settings/handlers/patches/a6ba167c65bdd8538aeca49186109e6f/install.php
+++ b/cp_684cb2e048560/include/modules/settings/handlers/patches/a6ba167c65bdd8538aeca49186109e6f/install.php
@@ -1,0 +1,15 @@
+<?php
+update("ALTER TABLE uni_clients ADD COLUMN gender enum('male','female','other') DEFAULT NULL");
+update("ALTER TABLE uni_clients ADD COLUMN role enum('sponsor','model') DEFAULT NULL");
+update("ALTER TABLE uni_clients ADD COLUMN preferred_gender enum('male','female','both') DEFAULT NULL");
+update("ALTER TABLE uni_clients ADD COLUMN verify_gesture varchar(255) DEFAULT NULL COMMENT 'Verification gesture'");
+update("ALTER TABLE uni_clients ADD COLUMN verify_photo varchar(255) DEFAULT NULL COMMENT 'Verification photo'");
+update("ALTER TABLE uni_clients ADD COLUMN social_links text DEFAULT NULL COMMENT 'Social networks'");
+update("ALTER TABLE uni_clients ADD COLUMN age int(11) DEFAULT NULL COMMENT 'Age (18+)'");
+update("ALTER TABLE uni_clients ADD COLUMN city varchar(255) DEFAULT NULL COMMENT 'City name'");
+update("ALTER TABLE uni_clients ADD COLUMN phone varchar(50) DEFAULT NULL COMMENT 'Unique phone number'");
+update("ALTER TABLE uni_clients ADD COLUMN description text DEFAULT NULL COMMENT 'Profile description'");
+update("ALTER TABLE uni_clients ADD COLUMN is_email_verified tinyint(1) NOT NULL DEFAULT 0 COMMENT 'Email confirmed'");
+update("ALTER TABLE uni_clients ADD COLUMN is_phone_verified tinyint(1) NOT NULL DEFAULT 0 COMMENT 'Phone confirmed'");
+update("UPDATE uni_settings SET value=? WHERE name=?", array('4.10.2','systems_patch_version'));
+?>

--- a/systems/ajax/profile/reg_finish.php
+++ b/systems/ajax/profile/reg_finish.php
@@ -3,6 +3,18 @@
 $error = [];
 
 $user_login = clear( $_POST["user_login"] );
+$user_age = (int)$_POST["user_age"];
+$user_gender = clear($_POST["user_gender"]);
+$user_role = clear($_POST["user_role"]);
+$user_city = clear($_POST["user_city"]);
+$user_email_field = clear($_POST["user_email"]);
+$user_photo = clear($_POST["user_photo"]);
+$user_description = clear($_POST["user_description"]);
+$user_preferences = clear($_POST["user_preferences"]);
+$user_phone_unique = clear($_POST["user_phone"]);
+$user_social = clear($_POST["user_social"]);
+$user_gesture = clear($_POST["user_gesture"]);
+
 $user_name = clear( $_POST["user_name"] );
 $user_code_login = (int)$_POST["user_code_login"];
 $user_pass = clear( $_POST["user_pass"] );
@@ -71,7 +83,25 @@ if(!$user_name){
 
 if( !$error ){
 
- $result = $Profile->auth_reg(array("method"=>$settings["registration_method"],"email"=>$user_email,"phone"=>$user_phone,"name"=>$user_name, "activation" => 1, "pass" => $user_pass));
+ $result = $Profile->auth_reg([
+    "method"=>$settings["registration_method"],
+    "email"=>$user_email,
+    "phone"=>$user_phone,
+    "name"=>$user_name,
+    "activation" => 0,
+    "pass" => $user_pass,
+    "age"=>$user_age,
+    "gender"=>$user_gender,
+    "role"=>$user_role,
+    "city"=>$user_city,
+    "email_field"=>$user_email_field,
+    "photo"=>$user_photo,
+    "description"=>$user_description,
+    "preferences"=>$user_preferences,
+    "phone_unique"=>$user_phone_unique,
+    "social_links"=>$user_social,
+    "gesture"=>$user_gesture
+ ]);
 
  echo json_encode( array( "status"=>$result["status"],"answer" => $result["answer"], "reg" => 1, "location" => _link( "user/".$result["data"]["clients_id_hash"] ) ) );
 

--- a/systems/ajax/profile/registration.php
+++ b/systems/ajax/profile/registration.php
@@ -2,6 +2,14 @@
 
 $error = [];
 
+$user_name = clear($_POST["user_name"]);
+$user_age = (int)$_POST["user_age"];
+$user_gender = clear($_POST["user_gender"]);
+$user_role = clear($_POST["user_role"]);
+$user_city = clear($_POST["user_city"]);
+$user_email_field = clear($_POST["user_email"]);
+$_SESSION["reg_fields"] = ["name"=>$user_name,"age"=>$user_age,"gender"=>$user_gender,"role"=>$user_role,"city"=>$user_city,"email"=>$user_email_field];
+
 $user_login = clear($_POST["user_login"]);
 
 if($settings["registration_method"] == 1){

--- a/systems/classes/Profile.php
+++ b/systems/classes/Profile.php
@@ -821,7 +821,34 @@ class Profile{
      
      $clients_id_hash = md5($array["email"] ? $array["email"] : $array["phone"]);
 
-     $insert_id = insert("INSERT INTO uni_clients(clients_pass,clients_email,clients_phone,clients_name,clients_surname,clients_ip,clients_id_hash,clients_status,clients_datetime_add,clients_notifications,clients_social_identity,clients_avatar,clients_ref_id,clients_verification_code)VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?)", array($password_hash,$array["email"],$array["phone"],$array["name"],$array["surname"],clear($_SERVER["REMOTE_ADDR"]),$clients_id_hash,intval($array["activation"]), date("Y-m-d H:i:s"), $notifications,$array["social_link"],$array["avatar"],genRefId(),genVerificationCode())); 
+     $insert_id = smart_insert('uni_clients', [
+        'clients_pass' => $password_hash,
+        'clients_email' => $array['email'],
+        'clients_phone' => $array['phone'],
+        'clients_name' => $array['name'],
+        'clients_surname' => $array['surname'],
+        'clients_ip' => clear($_SERVER['REMOTE_ADDR']),
+        'clients_id_hash' => $clients_id_hash,
+        'clients_status' => 0,
+        'clients_datetime_add' => date('Y-m-d H:i:s'),
+        'clients_notifications' => $notifications,
+        'clients_social_identity' => $array['social_link'],
+        'clients_avatar' => $array['avatar'],
+        'clients_ref_id' => genRefId(),
+        'clients_verification_code' => genVerificationCode(),
+        'gender' => $array['gender'],
+        'role' => $array['role'],
+        'preferred_gender' => $array['preferences'],
+        'age' => $array['age'],
+        'social_links' => $array['social_links'],
+        'verify_gesture' => $array['gesture'],
+        'verify_photo' => $array['photo'],
+        'description' => $array['description'],
+        'city' => $array['city'],
+        'phone' => $array['phone_unique'],
+        'is_email_verified' => 0,
+        'is_phone_verified' => 0
+     ]);
 
      $_SESSION['profile']['id'] = $insert_id;
 

--- a/templates/include/auth.php
+++ b/templates/include/auth.php
@@ -127,17 +127,54 @@
       <button class="button-style-custom schema-color-button color-green action-reg-verify mt20" ><?php echo $ULang->t("Продолжить"); ?></button>                   
     </div>
 
+
     <div class="auth-block-right-box-tab-1-3" >
 
-      <input type="text"  class="form-control input-style2-custom" placeholder="<?php echo $ULang->t("Ваше имя"); ?>" name="user_name">
-      <div class="msg-error mb10" data-name="user_name" ></div>
+      <div class="reg-step reg-step-1" >
+        <input type="text"  class="form-control input-style2-custom" placeholder="<?php echo $ULang->t('Ваше имя'); ?>" name="user_name">
+        <div class="msg-error mb10" data-name="user_name" ></div>
 
-      <input type="password"  class="form-control input-style2-custom" placeholder="<?php echo $ULang->t("Пароль"); ?>" maxlength="25" name="user_pass">
-      <div class="msg-error mb10" data-name="user_pass" ></div>
+        <input type="number"  class="form-control input-style2-custom" placeholder="<?php echo $ULang->t('Возраст'); ?>" name="user_age">
+        <div class="msg-error mb10" data-name="user_age" ></div>
 
-      <button class="button-style-custom schema-color-button color-green action-reg-finish mt20" ><?php echo $ULang->t("Завершить регистрацию"); ?></button>           
+        <input type="text"  class="form-control input-style2-custom" placeholder="<?php echo $ULang->t('Пол'); ?>" name="user_gender">
+        <div class="msg-error mb10" data-name="user_gender" ></div>
+
+        <input type="text"  class="form-control input-style2-custom" placeholder="<?php echo $ULang->t('Роль'); ?>" name="user_role">
+        <div class="msg-error mb10" data-name="user_role" ></div>
+
+        <input type="text"  class="form-control input-style2-custom" placeholder="<?php echo $ULang->t('Город'); ?>" name="user_city">
+        <div class="msg-error mb10" data-name="user_city" ></div>
+
+        <input type="text"  class="form-control input-style2-custom" placeholder="<?php echo $ULang->t('E-mail'); ?>" name="user_email">
+        <div class="msg-error mb10" data-name="user_email" ></div>
+
+        <button class="button-style-custom schema-color-button color-green action-reg-step1 mt20" ><?php echo $ULang->t('Продолжить'); ?></button>
+      </div>
+
+      <div class="reg-step reg-step-2" style="display:none;" >
+        <input type="file" class="form-control mb10" name="user_photo">
+        <textarea class="form-control input-style2-custom" placeholder="<?php echo $ULang->t('Описание'); ?>" name="user_description"></textarea>
+        <div class="msg-error mb10" data-name="user_description" ></div>
+
+        <input type="text"  class="form-control input-style2-custom" placeholder="<?php echo $ULang->t('Предпочтения'); ?>" name="user_preferences">
+        <div class="msg-error mb10" data-name="user_preferences" ></div>
+
+        <input type="text"  class="form-control input-style2-custom" placeholder="<?php echo $ULang->t('Телефон'); ?>" name="user_phone">
+        <div class="msg-error mb10" data-name="user_phone" ></div>
+
+        <input type="password"  class="form-control input-style2-custom" placeholder="<?php echo $ULang->t('Пароль'); ?>" maxlength="25" name="user_pass">
+        <div class="msg-error mb10" data-name="user_pass" ></div>
+
+        <input type="text"  class="form-control input-style2-custom" placeholder="<?php echo $ULang->t('Ссылки на соцсети'); ?>" name="user_social">
+        <div class="msg-error mb10" data-name="user_social" ></div>
+
+        <input type="file" class="form-control mb10" name="user_gesture">
+
+        <button class="button-style-custom schema-color-button color-green action-reg-finish mt20" ><?php echo $ULang->t('Завершить регистрацию'); ?></button>
+      </div>
+
     </div>
-
     <?php if($settings["authorization_social"]){ ?>
 
     <div class="mt20" ></div>

--- a/templates/js/auth.js
+++ b/templates/js/auth.js
@@ -175,15 +175,35 @@ $(document).ready(function () {
       e.preventDefault();
 
    });
+   $(document).on("click",".action-reg-step1", function (e) {
+      $(".reg-step-1").hide();
+      $(".reg-step-2").show();
+   });
 
-   $(document).on('click','.action-reg-finish', function (e) {  
+
+  $(document).on('click','.action-reg-finish', function (e) {
       
       $(".msg-error").hide();
       var this_ = $(this);
       
       showLoadProcess(this_);
 
-      $.ajax({type: "POST",url: url_path + "systems/ajax/controller.php",data: "user_login=" + $(".auth-block-tab-reg input[name=user_login]").val() + "&user_code_login=" + $(".auth-block-tab-reg input[name=user_code_login]").val() + "&user_pass=" + $(".auth-block-tab-reg input[name=user_pass]").val() + "&user_name=" + $(".auth-block-tab-reg input[name=user_name]").val() + "&action=profile/reg_finish",dataType: "json",cache: false,success: function (data) { 
+      $.ajax({type: "POST",url: url_path + "systems/ajax/controller.php",data: "user_login=" + $(".auth-block-tab-reg input[name=user_login]").val() +
+               "&user_code_login=" + $(".auth-block-tab-reg input[name=user_code_login]").val() +
+               "&user_pass=" + $(".auth-block-tab-reg input[name=user_pass]").val() +
+               "&user_name=" + $(".auth-block-tab-reg input[name=user_name]").val() +
+               "&user_age=" + $(".auth-block-tab-reg input[name=user_age]").val() +
+               "&user_gender=" + $(".auth-block-tab-reg input[name=user_gender]").val() +
+               "&user_role=" + $(".auth-block-tab-reg input[name=user_role]").val() +
+               "&user_city=" + $(".auth-block-tab-reg input[name=user_city]").val() +
+               "&user_email=" + $(".auth-block-tab-reg input[name=user_email]").val() +
+               "&user_photo=" + $(".auth-block-tab-reg input[name=user_photo]").val() +
+               "&user_description=" + $(".auth-block-tab-reg textarea[name=user_description]").val() +
+               "&user_preferences=" + $(".auth-block-tab-reg input[name=user_preferences]").val() +
+               "&user_phone=" + $(".auth-block-tab-reg input[name=user_phone]").val() +
+               "&user_social=" + $(".auth-block-tab-reg input[name=user_social]").val() +
+               "&user_gesture=" + $(".auth-block-tab-reg input[name=user_gesture]").val() +
+               "&action=profile/reg_finish",dataType: "json",cache: false,success: function (data) {
 
          if( data["status"] == true ){
             

--- a/templates/profile_sidebar.tpl
+++ b/templates/profile_sidebar.tpl
@@ -12,13 +12,13 @@
         <div class="user-card-company-name" ><?php echo $user["clients_name_company"]; ?></div>
         <?php
     }
-    if($user["clients_verification_status"]){
+    if($user["is_phone_verified"] || $user["is_email_verified"] || $user["clients_verification_status"]){
         ?>
         <div class="user-card-verification-box">
             <span class="user-card-verification-status" ><?php echo $ULang->t("Профиль подтвержден"); ?></span>
-            <div><i class="las la-check"></i> <?php echo $ULang->t("Телефон подтверждён"); ?></div> 
-            <div><i class="las la-check"></i> <?php echo $ULang->t("Email подтверждён"); ?></div> 
-            <div><i class="las la-check"></i> <?php echo $ULang->t("Документы и фото проверены"); ?></div>                              
+            <?php if($user["is_phone_verified"]){ ?><div><i class="las la-check"></i> <?php echo $ULang->t("Телефон подтверждён"); ?></div><?php } ?>
+            <?php if($user["is_email_verified"]){ ?><div><i class="las la-check"></i> <?php echo $ULang->t("Email подтверждён"); ?></div><?php } ?>
+            <?php if($user["clients_verification_status"]){ ?><div><i class="las la-check"></i> <?php echo $ULang->t("Документы и фото проверены"); ?></div><?php } ?>
         </div>
         <?php
     }else{


### PR DESCRIPTION
## Summary
- expand registration form with more fields
- send new profile data in auth JS
- store new values during registration
- save draft users with extended attributes
- display verification flags in profiles and admin
- add DB migration patch for new columns

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68588d63dde48332b1978e2f96441d82