### PR TITLE
Implement daily chat limits

### DIFF
--- a/cp_684cb2e048560/include/modules/settings/handlers/include/chat_limits.php
+++ b/cp_684cb2e048560/include/modules/settings/handlers/include/chat_limits.php
@@ -1,0 +1,4 @@
+<?php
+update("UPDATE uni_settings SET value=? WHERE name=?", [intval($_POST['chat_free_per_day']),'chat_free_per_day']);
+update("UPDATE uni_settings SET value=? WHERE name=?", [intval($_POST['chat_bonus_topup']),'chat_bonus_topup']);
+?>

--- a/cp_684cb2e048560/include/modules/settings/tabs/chat_limits.php
+++ b/cp_684cb2e048560/include/modules/settings/tabs/chat_limits.php
@@ -1,0 +1,17 @@
+<div class="tab-pane fade <?php if($tab == "chat_limits"){ echo 'active show'; } ?>" id="tab-chat_limits" role="tabpanel" aria-labelledby="tab-chat_limits">
+
+ <div class="form-group row d-flex align-items-center mb-5">
+    <label class="col-lg-3 form-control-label">Бесплатных чатов в сутки</label>
+    <div class="col-lg-2">
+        <input type="number" max="30" min="0" class="form-control" name="chat_free_per_day" value="<?php echo $settings["chat_free_per_day"]; ?>">
+    </div>
+ </div>
+
+ <div class="form-group row d-flex align-items-center mb-5">
+    <label class="col-lg-3 form-control-label">Бонус чатов за пополнение</label>
+    <div class="col-lg-2">
+        <input type="number" class="form-control" name="chat_bonus_topup" value="<?php echo $settings["chat_bonus_topup"]; ?>">
+    </div>
+ </div>
+
+</div>

--- a/systems/ajax/chat/send_chat.php
+++ b/systems/ajax/chat/send_chat.php
@@ -8,7 +8,15 @@ $voice = clear($_POST["voice"]);
 $duration = (int)$_POST["duration"];
 
 if(!$support){
+      $ChatLimits = new ChatLimits();
       $getUser = getOne("select * from uni_chat_users where chat_users_id_hash=? and chat_users_id_user=?", array($id_hash,intval($_SESSION["profile"]["id"])) );
+      $isNew = (int)getOne("select count(*) as total from uni_chat_messages where chat_messages_id_hash=? and chat_messages_id_user=?", [$id_hash,intval($_SESSION['profile']['id'])])["total"] == 0;
+      if($isNew){
+          if(!$ChatLimits->useChat(intval($_SESSION['profile']['id']))){
+              echo json_encode(["error"=>"limit"]);
+              exit;
+          }
+      }
    $Profile->sendChat( array( "id_ad" => $getUser["chat_users_id_ad"], "id_hash" => $id_hash, "text" => $text, "user_from" => intval($_SESSION["profile"]["id"]), "user_to" => $getUser["chat_users_id_interlocutor"], "attach" => $attach, 'voice' => $voice, 'duration' => $duration, "firebase" => true ) );
    }else{
          $Profile->sendChat( array( "support" => 1, "id_hash" => $id_hash, "text" => $text, "user_from" => intval($_SESSION["profile"]["id"]), "user_to" => 0, "attach" => $attach, "firebase" => true ) );

--- a/systems/classes/ChatLimits.php
+++ b/systems/classes/ChatLimits.php
@@ -1,0 +1,47 @@
+<?php
+class ChatLimits {
+    public function getToday($userId){
+        return findOne('uni_chat_limits','user_id=? and date=?',[$userId,date('Y-m-d')]);
+    }
+
+    public function contactsUsedToday($userId){
+        $row = $this->getToday($userId);
+        return $row ? (int)$row['contacts_used'] : 0;
+    }
+
+    private function incrementContacts($userId){
+        $row = $this->getToday($userId);
+        if($row){
+            update('update uni_chat_limits set contacts_used=contacts_used+1 where id=?',[$row['id']]);
+        }else{
+            insert('INSERT INTO uni_chat_limits(user_id,date,messages_sent,contacts_used)VALUES(?,?,?,?)',[$userId,date('Y-m-d'),0,1]);
+        }
+    }
+
+    public function remainingChats($userId){
+        global $settings;
+        $free = min(30, intval($settings['chat_free_per_day']));
+        $bonus = (int)findOne('uni_clients','clients_id=?',[$userId])['clients_bonus_chats'];
+        $used = $this->contactsUsedToday($userId);
+        $limit = $free + $bonus;
+        return max(0, $limit - $used);
+    }
+
+    public function useChat($userId){
+        global $settings;
+        $free = min(30, intval($settings['chat_free_per_day']));
+        $bonus = (int)findOne('uni_clients','clients_id=?',[$userId])['clients_bonus_chats'];
+        $used = $this->contactsUsedToday($userId);
+        if($used >= $free){
+            if($bonus <= 0) return false;
+            update('update uni_clients set clients_bonus_chats=clients_bonus_chats-1 where clients_id=?',[$userId]);
+        }
+        $this->incrementContacts($userId);
+        return true;
+    }
+
+    public function addBonus($userId,$count){
+        update('update uni_clients set clients_bonus_chats=clients_bonus_chats+? where clients_id=?',[$count,$userId]);
+    }
+}
+?>

--- a/systems/classes/Profile.php
+++ b/systems/classes/Profile.php
@@ -1483,6 +1483,10 @@ class Profile{
           if($output_param["action"] == "balance"){
 
              $this->actionBalance(array("id_user"=>$output_param["id_user"],"summa"=>$output_param["amount"],"title"=>$output_param["title"],"id_order"=>generateOrderId(),"email" => $user["clients_email"],"name" => $user["clients_name"], "note" => $output_param["title"]),"+");
+             if($settings['chat_bonus_topup']){
+                 $ChatLimits = new ChatLimits();
+                 $ChatLimits->addBonus($output_param['id_user'], intval($settings['chat_bonus_topup']));
+             }
 
              if($settings["bonus_program"]["balance"]["status"] && $settings["bonus_program"]["balance"]["price"]){
                  $bonus = $this->calcBonus($output_param["amount"]);

--- a/templates/profile_sidebar.tpl
+++ b/templates/profile_sidebar.tpl
@@ -36,7 +36,10 @@
         }
     }                        
  ?>
- <p><?php echo $ULang->t("На"); ?> <?php echo $ULang->t($settings["site_name"]); ?> <?php echo $ULang->t("с"); ?> <?php echo date("d.m.Y", strtotime($user["clients_datetime_add"])); ?></p>  
+<p><?php echo $ULang->t("На"); ?> <?php echo $ULang->t($settings["site_name"]); ?> <?php echo $ULang->t("с"); ?> <?php echo date("d.m.Y", strtotime($user["clients_datetime_add"])); ?></p>
+<?php if($data["advanced"]){ ?>
+<p><?php echo $ULang->t("Осталось чатов сегодня"); ?>: <?php $ChatLimits=new ChatLimits(); echo $ChatLimits->remainingChats($_SESSION['profile']['id']); ?></p>
+<?php } ?>
 
  <div class="board-view-stars">
      


### PR DESCRIPTION
## Summary
- add ChatLimits model for tracking daily chat usage
- enforce chat limit when starting new dialog
- award bonus chats after balance top-up
- show remaining chats on the profile page
- expose chat limit settings in admin panel

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6859975147588332b0594211f96a0eb1