### PR TITLE
Add coin package support

### DIFF
--- a/cp_684cb2e048560/include/modules/settings/handlers/include/payments.php
+++ b/cp_684cb2e048560/include/modules/settings/handlers/include/payments.php
@@ -12,4 +12,17 @@ if(isset($_POST["payment_param"])){
 
 }
 
+if(isset($_POST['coin_packages'])){
+   $packages = [];
+   foreach (explode("\n", $_POST['coin_packages']) as $line){
+       $line = trim($line);
+       if(!$line) continue;
+       list($country,$coins,$price,$bonus) = array_map('trim', explode('|',$line) + [null,null,null,null]);
+       if($country !== null){
+           $packages[$country][] = ['coins'=>(int)$coins,'price'=>(float)$price,'bonus'=>(int)$bonus];
+       }
+   }
+   update("UPDATE uni_settings SET value=? WHERE name=?", array(json_encode($packages),'coin_packages'));
+}
+
 ?>

--- a/cp_684cb2e048560/include/modules/settings/tabs/payments.php
+++ b/cp_684cb2e048560/include/modules/settings/tabs/payments.php
@@ -47,12 +47,20 @@
 
             </div>                              
             <?php
-         }
-       }
-    ?>  
+        }
+      }
+   ?>
 
 </div>
-</div>         
+</div>
+
+<div class="form-group row d-flex align-items-center mb-5">
+  <label class="col-lg-3 form-control-label">Пакеты монет</label>
+  <div class="col-lg-9">
+      <textarea class="form-control" name="coin_packages" rows="5"><?php echo htmlspecialchars($settings["coin_packages"] ?? ""); ?></textarea>
+      <small>Формат строки: код_страны|монет|цена|бонус чатов</small>
+  </div>
+</div>
 
 <div class="param-payment" ></div>
 

--- a/systems/ajax/profile/balance_payment.php
+++ b/systems/ajax/profile/balance_payment.php
@@ -5,11 +5,26 @@ $error = [];
 $getUser = findOne("uni_clients", "clients_id=?", [$_SESSION['profile']['id']]);
 
 $amount = 0;
+$coins = 0;
+$bonus = 0;
 
-if($_POST["amount"]){
-   $amount = round($_POST["amount"],2);
-}elseif($_POST["change_amount"]){
-   $amount = round($_POST["change_amount"],2);
+if(isset($_POST['package_index'])){
+   $packages = $settings['coin_packages'] ? json_decode($settings['coin_packages'], true) : [];
+   $country = $_SESSION['geo']['data']['country_alias'] ?? $settings['country_default'];
+   if(isset($packages[$country][$_POST['package_index']])){
+       $p = $packages[$country][$_POST['package_index']];
+       $amount = $p['price'];
+       $coins = $p['coins'];
+       $bonus = $p['bonus'];
+   }
+}
+
+if(!$amount){
+   if($_POST["amount"]){
+      $amount = round($_POST["amount"],2);
+   }elseif($_POST["change_amount"]){
+      $amount = round($_POST["change_amount"],2);
+   }
 }
 
 if(!$_POST["payment"]){
@@ -30,9 +45,9 @@ if(!$amount){
 
 if(!$error){
 
- $answer = $Profile->payMethod( $_POST["payment"], array( "amount" => $amount, "name" => $getUser["clients_name"], "email" => $getUser["clients_email"], "phone" => $getUser["clients_phone"], "id_order" => generateOrderId(), "id_user" => $_SESSION['profile']['id'], "action" => "balance", "title" => $static_msg["19"] . " - " . $settings["site_name"] ) );
+ $answer = $Profile->payMethod( $_POST["payment"], array( "amount" => $amount, "name" => $getUser["clients_name"], "email" => $getUser["clients_email"], "phone" => $getUser["clients_phone"], "id_order" => generateOrderId(), "id_user" => $_SESSION['profile']['id'], "action" => "balance", "title" => $static_msg["19"] . " - " . $settings["site_name"], "coins"=>$coins, "bonus"=>$bonus ) );
 
-  echo json_encode( array( "status" => true, "redirect" => $answer ) );
+  echo json_encode( array( "status" => true, "redirect" => $answer, "coins"=>$coins, "bonus_chats"=>$bonus ) );
 
 }else{
 


### PR DESCRIPTION
## Summary
- allow editing coin packages per country in admin payment settings
- parse and save coin packages
- use selected package in balance payment processing
- include coins and bonus chats in API responses

## Testing
- `php` lint **failed: command not found**

------
https://chatgpt.com/codex/tasks/task_b_68599a0afe1c8332b8974ddc138a7833